### PR TITLE
Update files type to FileElement

### DIFF
--- a/src/request/payload/event.ts
+++ b/src/request/payload/event.ts
@@ -1227,7 +1227,7 @@ export interface GenericMessageEvent extends SlackEvent<"message"> {
   channel_type: AnyChannelType;
   attachments?: MessageAttachment[];
   blocks?: AnyMessageBlock[];
-  files?: File[];
+  files?: FileElement[];
   edited?: {
     user: string;
     ts: string;
@@ -1387,7 +1387,7 @@ export interface FileShareMessageEvent extends SlackEvent<"message"> {
   text: string;
   attachments?: MessageAttachment[];
   blocks?: AnyMessageBlock[];
-  files?: File[];
+  files?: FileElement[];
   upload?: boolean;
   display_as_bot?: boolean;
   x_files?: string[];

--- a/src_deno/request/payload/event.ts
+++ b/src_deno/request/payload/event.ts
@@ -1227,7 +1227,7 @@ export interface GenericMessageEvent extends SlackEvent<"message"> {
   channel_type: AnyChannelType;
   attachments?: MessageAttachment[];
   blocks?: AnyMessageBlock[];
-  files?: File[];
+  files?: FileElement[];
   edited?: {
     user: string;
     ts: string;
@@ -1387,7 +1387,7 @@ export interface FileShareMessageEvent extends SlackEvent<"message"> {
   text: string;
   attachments?: MessageAttachment[];
   blocks?: AnyMessageBlock[];
-  files?: File[];
+  files?: FileElement[];
   upload?: boolean;
   display_as_bot?: boolean;
   x_files?: string[];


### PR DESCRIPTION
These types should be using `FileElement` rather than the native `File` type. 

MessageItem's files type is currently `FileElement` and I believe it's the proper usage for all events that use `files`