### PR TITLE
Create TombstoneMessageEvent

### DIFF
--- a/src/request/payload/event.ts
+++ b/src/request/payload/event.ts
@@ -1,8 +1,8 @@
 import {
   AnyMessageBlock,
+  HomeTabView,
   MessageAttachment,
   MessageMetadata,
-  HomeTabView,
 } from "slack-web-api-client";
 
 export type AnySlackEvent =
@@ -1205,7 +1205,8 @@ export type AnyMessageItem =
   | FileShareMessageEvent
   | MeMessageEvent
   | MessageRepliedEvent
-  | ThreadBroadcastMessageEvent;
+  | ThreadBroadcastMessageEvent
+  | TombstoneMessageEvent;
 
 export type AnyMessageMetadataEvent =
   | MessageMetadataPostedEvent
@@ -1473,6 +1474,25 @@ export interface ThreadBroadcastMessageEvent extends SlackEvent<"message"> {
   client_msg_id: string;
   channel: string;
   channel_type: AnyChannelType;
+}
+
+// Undocumented message subtype but it can be created when a message is deleted that contains threaded replies
+
+export interface TombstoneMessageEvent extends SlackEvent<"message"> {
+  type: "message";
+  subtype: "tombstone";
+  text: string;
+  user: string;
+  hidden: boolean;
+  ts: string;
+  thread_ts: string;
+  parent_user_id: string;
+  reply_count: number;
+  reply_users_count: number;
+  latest_reply: string;
+  reply_users: string[];
+  is_locked: boolean;
+  subscribed: boolean;
 }
 
 export interface MessageMetadataPostedEvent

--- a/src/request/payload/event.ts
+++ b/src/request/payload/event.ts
@@ -1476,7 +1476,8 @@ export interface ThreadBroadcastMessageEvent extends SlackEvent<"message"> {
   channel_type: AnyChannelType;
 }
 
-// Undocumented message subtype but it can be created when a message is deleted that contains threaded replies
+// Tombstone is currently an undocumented message subtype.
+// One reproducible tombstone example is deleting a message which contains threaded replies.
 
 export interface TombstoneMessageEvent extends SlackEvent<"message"> {
   type: "message";

--- a/src/request/payload/event.ts
+++ b/src/request/payload/event.ts
@@ -1476,7 +1476,6 @@ export interface ThreadBroadcastMessageEvent extends SlackEvent<"message"> {
   channel_type: AnyChannelType;
 }
 
-// Tombstone is currently an undocumented message subtype.
 // One reproducible tombstone example is deleting a message which contains threaded replies.
 
 export interface TombstoneMessageEvent extends SlackEvent<"message"> {

--- a/src_deno/request/payload/event.ts
+++ b/src_deno/request/payload/event.ts
@@ -1205,7 +1205,8 @@ export type AnyMessageItem =
   | FileShareMessageEvent
   | MeMessageEvent
   | MessageRepliedEvent
-  | ThreadBroadcastMessageEvent;
+  | ThreadBroadcastMessageEvent
+  | TombstoneMessageEvent;
 
 export type AnyMessageMetadataEvent =
   | MessageMetadataPostedEvent
@@ -1473,6 +1474,26 @@ export interface ThreadBroadcastMessageEvent extends SlackEvent<"message"> {
   client_msg_id: string;
   channel: string;
   channel_type: AnyChannelType;
+}
+
+// Tombstone is currently an undocumented message subtype.
+// One reproducible tombstone example is deleting a message which contains threaded replies.
+
+export interface TombstoneMessageEvent extends SlackEvent<"message"> {
+  type: "message";
+  subtype: "tombstone";
+  text: string;
+  user: string;
+  hidden: boolean;
+  ts: string;
+  thread_ts: string;
+  parent_user_id: string;
+  reply_count: number;
+  reply_users_count: number;
+  latest_reply: string;
+  reply_users: string[];
+  is_locked: boolean;
+  subscribed: boolean;
 }
 
 export interface MessageMetadataPostedEvent

--- a/src_deno/request/payload/event.ts
+++ b/src_deno/request/payload/event.ts
@@ -1476,7 +1476,6 @@ export interface ThreadBroadcastMessageEvent extends SlackEvent<"message"> {
   channel_type: AnyChannelType;
 }
 
-// Tombstone is currently an undocumented message subtype.
 // One reproducible tombstone example is deleting a message which contains threaded replies.
 
 export interface TombstoneMessageEvent extends SlackEvent<"message"> {


### PR DESCRIPTION
### Why?
The tombstone event can be triggered when a message is deleted that contains threaded replies. As I have used the app, I've seen it show in both `MessageDeletedEvent` and `MessageChangedEvent`. Therefore, it should be part of AnyMessageItem.

#### References (search for `tombstone`):
- https://api.slack.com/messaging/files#removing
- https://slack.com/help/articles/12914005852819-Slack-Connect--Data-loss-prevention

Actual example from one of my slack apps:
```
{
  type: 'message',
  subtype: 'message_deleted',
  previous_message: {
    type: 'message',
    subtype: 'tombstone',
    text: 'This message was deleted.',
    user: 'USLACKBOT',
    hidden: true,
    ts: '1704604884.175949',
    thread_ts: '1704604884.175949',
    parent_user_id: 'USLACKBOT',
    reply_count: 0,
    reply_users_count: 0,
    latest_reply: '0000000000.000000',
    reply_users: [],
    is_locked: false,
    subscribed: false
  },
  channel: 'C061C15S0E5',
  hidden: true,
  deleted_ts: '1704604884.175949',
  event_ts: '1704604959.000800',
  ts: '1704604959.000800',
  channel_type: 'channel'
}
```

### Additional Note

This gap should also be brought up with the Slack technical documentation team as it should be mentioned more explicitly in the API documentation.