### PR TITLE
add is_forgotten user profile property

### DIFF
--- a/src/request/payload/event.ts
+++ b/src/request/payload/event.ts
@@ -948,6 +948,7 @@ export interface UserProfileChangedEvent
     team_id: string;
     name: string;
     deleted: boolean;
+    is_forgotten: boolean;
     color: string;
     real_name: string;
     tz: string;

--- a/src/request/payload/event.ts
+++ b/src/request/payload/event.ts
@@ -948,7 +948,7 @@ export interface UserProfileChangedEvent
     team_id: string;
     name: string;
     deleted: boolean;
-    is_forgotten: boolean;
+    is_forgotten?: boolean;
     color: string;
     real_name: string;
     tz: string;

--- a/src_deno/request/payload/event.ts
+++ b/src_deno/request/payload/event.ts
@@ -948,6 +948,7 @@ export interface UserProfileChangedEvent
     team_id: string;
     name: string;
     deleted: boolean;
+    is_forgotten: boolean;
     color: string;
     real_name: string;
     tz: string;

--- a/src_deno/request/payload/event.ts
+++ b/src_deno/request/payload/event.ts
@@ -948,7 +948,7 @@ export interface UserProfileChangedEvent
     team_id: string;
     name: string;
     deleted: boolean;
-    is_forgotten: boolean;
+    is_forgotten?: boolean;
     color: string;
     real_name: string;
     tz: string;


### PR DESCRIPTION
Adding `is_forgotten` to the user payload for the `user_profile_changed` event.

---

While unfortunately not in the [API docs](https://api.slack.com/events/user_profile_changed) for the `user_profile_changed` event, there are two steps for removing a user from a workspace:
1. "**Deactivate**" (in the UI) - sets the profile to `deleted=true`, admin can reactivate the profile later
2. "**Delete**" (in the UI) - sets the profile to `is_forgotten=true` and overwrites all PII fields of the profile with placeholder values like "Deactivated User" (for GDPR-related reasons)

Confirmed with Slack support:
> The Delete action simply removes a user's profile information after their account has been deactivated: https://slack.com/intl/en-au/help/articles/360000360443-Delete-profile-information-from-Slack
> 
> It does not actually delete the user object, and you will see the is_forgotten flag set to true which is part of the GDPR system used to ensure that the user can't be re-activated by an admin and that their accounts and profile are permanently gone.
> 
> Otherwise, if a user has just been deactivated, but not had their profile scrubbed, they will show up as "deleted: true".

Examples event payloads:
**Deactivate**:
```
{
  "token": "...",
  "team_id": "TXXXXXX",
  "api_app_id": "AXXXXXXX",
  "event": {
    "user": {
      "id": "UXXXXXXX",
      "team_id": "TXXXXXX",
      "name": "stephentangcook",
      "deleted": true,
      "profile": {
        "title": "",
        "phone": "",
        "skype": "",
        "real_name": "Stephen Cook",
        "real_name_normalized": "Stephen Cook",
        "display_name": "Stephen Cook",
        "display_name_normalized": "Stephen Cook",
        "fields": {},
        "status_text": "",
        "status_emoji": "",
        "status_emoji_display_info": [],
        "status_expiration": 0,
        "avatar_hash": "e9e33cdb8b13",
        "image_original": "https://avatars.slack-edge.com/2024-01-17/6487859726674_e9e33cdb8b13282539bf_original.jpg",
        "is_custom_image": true,
        "first_name": "Stephen",
        "last_name": "Cook",
        "status_text_canonical": "",
        "team": "TXXXXXX"
      },
      "is_bot": false,
      "is_app_user": false,
      "updated": 1705514668
    },
    "cache_ts": 1705514668,
    "type": "user_profile_changed",
    "event_ts": "1705514668.022500"
  },
  "type": "event_callback",
  "event_id": "Ev06EQEVRUM7",
  "event_time": 1705514668,
  "authorizations": [
    {
      "enterprise_id": null,
      "team_id": "TXXXXXX",
      "user_id": "UXXXXXXX",
      "is_bot": true,
      "is_enterprise_install": false
    }
  ],
  "is_ext_shared_channel": false
}
```

Delete:
```
{
  "token": "...",
  "team_id": "TXXXXXX",
  "api_app_id": "AXXXXXXX",
  "event": {
    "user": {
      "id": "U06DX93DN8P",
      "team_id": "TXXXXXX",
      "name": "deactivateduser660836",
      "deleted": true,
      "profile": {
        "title": "",
        "phone": "",
        "skype": "",
        "real_name": "Deactivated User",
        "real_name_normalized": "Deactivated User",
        "display_name": "deactivateduser",
        "display_name_normalized": "deactivateduser",
        "fields": null,
        "status_text": "",
        "status_emoji": "",
        "status_emoji_display_info": [],
        "status_expiration": 0,
        "avatar_hash": "g849cc56ed76",
        "email": "deactivateduser660836-stephensslack-nxg3421@slack-corp.com",
        "huddle_state": "default_unset",
        "first_name": "Deactivated",
        "last_name": "User",
        "status_text_canonical": "",
        "team": "TXXXXXX"
      },
      "is_bot": false,
      "is_app_user": false,
      "updated": 1705514730,
      "is_forgotten": true
    },
    "cache_ts": 1705514730,
    "type": "user_profile_changed",
    "event_ts": "1705514730.024600"
  },
  "type": "event_callback",
  "event_id": "Ev06F0KBFYRE",
  "event_time": 1705514730,
  "authorizations": [
    {
      "enterprise_id": null,
      "team_id": "TXXXXXX",
      "user_id": "UXXXXXXX",
      "is_bot": true,
      "is_enterprise_install": false
    }
  ],
  "is_ext_shared_channel": false
}
```