### PR TITLE
Add @slack/socket-mode support

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -51,5 +51,6 @@ export * from "./request/payload/view-objects";
 
 export * from "./response/response";
 export * from "./socket-mode/socket-mode-client";
+export * from "./socket-mode/payload-handler";
 
 export * from "./utility/message-events";

--- a/src/socket-mode/payload-handler.ts
+++ b/src/socket-mode/payload-handler.ts
@@ -1,0 +1,49 @@
+interface fromSocketModeToRequestArgs {
+  url?: string;
+  body: Record<string, unknown>;
+  retryNum?: string;
+  retryReason?: string;
+}
+export function fromSocketModeToRequest({
+  url,
+  body,
+  retryNum,
+  retryReason,
+}: fromSocketModeToRequestArgs): Request {
+  const payload = JSON.stringify(body);
+  const headers: Record<string, string> = {
+    "content-type": "application/json",
+  };
+  if (retryNum) {
+    headers["x-slack-retry-num"] = retryNum;
+  }
+  if (retryReason) {
+    headers["x-slack-retry-reason"] = retryReason;
+  }
+  const options = {
+    method: "POST",
+    headers: new Headers(headers),
+    body: new Blob([payload]).stream(),
+    duplex: "half", // required when running on Node.js runtime
+  };
+  return new Request(url ?? "wss://localhost", options);
+}
+
+interface fromResponseToSocketModePayloadArgs {
+  response: Response;
+}
+export async function fromResponseToSocketModePayload({
+  response,
+}: fromResponseToSocketModePayloadArgs): Promise<Record<string, unknown>> {
+  let message: Record<string, unknown> = {};
+  if (response.body) {
+    const contentType = response.headers.get("Content-Type");
+    if (contentType && contentType.startsWith("text/plain")) {
+      const text = await response.text();
+      message = { text };
+    } else {
+      message = await response.json();
+    }
+  }
+  return message;
+}

--- a/src/socket-mode/socket-mode-client.ts
+++ b/src/socket-mode/socket-mode-client.ts
@@ -1,8 +1,11 @@
 import { SlackAPIClient, isDebugLogEnabled } from "slack-web-api-client";
 import { SlackApp } from "../app";
 import { ConfigError, SocketModeError } from "../errors";
-import { ExecutionContext } from "../execution-context";
 import { SlackSocketModeAppEnv } from "../app-env";
+import {
+  fromSocketModeToRequest,
+  fromResponseToSocketModePayload,
+} from "./payload-handler";
 
 // TODO: Implement proper reconnection logic
 // TODO: Add connection monitor like 1st party SDKs do
@@ -91,42 +94,22 @@ export class SocketModeClient {
               }
               return;
             }
-            const payload = JSON.stringify(data.payload);
-            console.log(payload);
-            const request: Request = new Request(ws.url, {
-              method: "POST",
-              headers: new Headers({ "content-type": "application/json" }),
-              body: new Blob([payload]).stream(),
-            });
-            const context: ExecutionContext = {
-              // deno-lint-ignore require-await
-              waitUntil: async (promise) => {
-                promise
-                  .then((res) => {
-                    const result = res ? ": " + res : "";
-                    console.info(
-                      `Completed a lazy listener execution${result}`,
-                    );
-                  })
-                  .catch((err) => {
-                    console.error(`Failed to run a lazy listener: ${err}`);
-                  });
-              },
+            const response = await app.run(
+              fromSocketModeToRequest({
+                url: ws.url,
+                body: data.payload,
+                retryNum: data.retry_attempt,
+                retryReason: data.retry_reason,
+              }),
+            );
+            const message: Record<string, unknown> = {
+              envelope_id: data.envelope_id,
             };
-            const response = await app.run(request, context);
-            // deno-lint-ignore no-explicit-any
-            let ack: any = { envelope_id: data.envelope_id };
-            if (response.body) {
-              const contentType = response.headers.get("Content-Type");
-              if (contentType && contentType.startsWith("text/plain")) {
-                const text = await response.text();
-                ack = { envelope_id: data.envelope_id, payload: { text } };
-              } else {
-                const json = await response.json();
-                ack = { envelope_id: data.envelope_id, payload: { ...json } };
-              }
+            const payload = await fromResponseToSocketModePayload({ response });
+            if (payload) {
+              message.payload = payload;
             }
-            ws.send(JSON.stringify(ack));
+            ws.send(JSON.stringify(message));
           } else {
             if (isDebugLogEnabled(app.env.SLACK_LOGGING_LEVEL)) {
               console.log(`*** Received non-JSON data ***\n ${ev.data}`);

--- a/src_deno/app.ts
+++ b/src_deno/app.ts
@@ -44,7 +44,7 @@ import {
 import {
   ResponseUrlSender,
   SlackAPIClient,
-} from "https://deno.land/x/slack_web_api_client@0.7.6/mod.ts";
+} from "https://deno.land/x/slack_web_api_client@0.8.0/mod.ts";
 import {
   builtBaseContext,
   SlackAppContext,
@@ -55,7 +55,7 @@ import { Middleware, PreAuthorizeMiddleware } from "./middleware/middleware.ts";
 import {
   isDebugLogEnabled,
   prettyPrint,
-} from "https://deno.land/x/slack_web_api_client@0.7.6/mod.ts";
+} from "https://deno.land/x/slack_web_api_client@0.8.0/mod.ts";
 import { Authorize } from "./authorization/authorize.ts";
 import { AuthorizeResult } from "./authorization/authorize-result.ts";
 import {
@@ -855,14 +855,13 @@ export class SlackApp<E extends SlackEdgeAppEnv | SlackSocketModeAppEnv> {
 
 export type StringOrRegExp = string | RegExp;
 
-export type EventRequest<E extends SlackAppEnv, T> = Extract<
-  AnySlackEventWithChannelId,
-  { type: T }
-> extends never ? SlackRequest<E, Extract<AnySlackEvent, { type: T }>>
-  : SlackRequestWithChannelId<
-    E,
-    Extract<AnySlackEventWithChannelId, { type: T }>
-  >;
+export type EventRequest<E extends SlackAppEnv, T> =
+  Extract<AnySlackEventWithChannelId, { type: T }> extends never
+    ? SlackRequest<E, Extract<AnySlackEvent, { type: T }>>
+    : SlackRequestWithChannelId<
+      E,
+      Extract<AnySlackEventWithChannelId, { type: T }>
+    >;
 
 export type FunctionExecutedEventCallbackIdPattern =
   | string

--- a/src_deno/authorization/single-team-authorize.ts
+++ b/src_deno/authorization/single-team-authorize.ts
@@ -3,7 +3,7 @@ import {
   AuthTestResponse,
   SlackAPIClient,
   SlackAPIError,
-} from "https://deno.land/x/slack_web_api_client@0.7.6/mod.ts";
+} from "https://deno.land/x/slack_web_api_client@0.8.0/mod.ts";
 import { Authorize } from "./authorize.ts";
 
 export const singleTeamAuthorize: Authorize = async (req) => {

--- a/src_deno/context/context.ts
+++ b/src_deno/context/context.ts
@@ -4,7 +4,7 @@ import {
   ChatPostMessageResponse,
   SlackAPIClient,
   WebhookParams,
-} from "https://deno.land/x/slack_web_api_client@0.7.6/mod.ts";
+} from "https://deno.land/x/slack_web_api_client@0.8.0/mod.ts";
 
 export interface PreAuthorizeSlackAppContext {
   isEnterpriseinstall?: boolean;

--- a/src_deno/index.ts
+++ b/src_deno/index.ts
@@ -2,7 +2,7 @@ export * from "./app.ts";
 export * from "./app-env.ts";
 export * from "./execution-context.ts";
 
-export * from "https://deno.land/x/slack_web_api_client@0.7.6/mod.ts";
+export * from "https://deno.land/x/slack_web_api_client@0.8.0/mod.ts";
 
 export * from "./errors.ts";
 export * from "./oauth/error-codes.ts";
@@ -51,5 +51,6 @@ export * from "./request/payload/view-objects.ts";
 
 export * from "./response/response.ts";
 export * from "./socket-mode/socket-mode-client.ts";
+export * from "./socket-mode/payload-handler.ts";
 
 export * from "./utility/message-events.ts";

--- a/src_deno/oauth-app.ts
+++ b/src_deno/oauth-app.ts
@@ -9,7 +9,7 @@ import {
   OAuthV2AccessResponse,
   OpenIDConnectTokenResponse,
   SlackAPIClient,
-} from "https://deno.land/x/slack_web_api_client@0.7.6/mod.ts";
+} from "https://deno.land/x/slack_web_api_client@0.8.0/mod.ts";
 import { toInstallation } from "./oauth/installation.ts";
 import {
   AfterInstallation,
@@ -110,6 +110,8 @@ export class SlackOAuthApp<E extends SlackOAuthEnv> extends SlackApp<E> {
         defaultOnStateValidationError,
       redirectUri: options.oauth?.redirectUri ?? this.env.SLACK_REDIRECT_URI,
       start: options.oauth?.start ?? defaultOAuthStart,
+      beforeInstallation: options.oauth?.beforeInstallation,
+      afterInstallation: options.oauth?.afterInstallation,
       callback: options.oauth?.callback ?? defaultOAuthCallback,
     };
     if (options.oidc) {

--- a/src_deno/oauth/callback.ts
+++ b/src_deno/oauth/callback.ts
@@ -1,4 +1,4 @@
-import { OAuthV2AccessResponse } from "https://deno.land/x/slack_web_api_client@0.7.6/mod.ts";
+import { OAuthV2AccessResponse } from "https://deno.land/x/slack_web_api_client@0.8.0/mod.ts";
 import { InvalidStateParameter, OAuthErrorCode } from "./error-codes.ts";
 import { Installation } from "./installation.ts";
 import {

--- a/src_deno/oauth/installation.ts
+++ b/src_deno/oauth/installation.ts
@@ -1,4 +1,4 @@
-import { OAuthV2AccessResponse } from "https://deno.land/x/slack_web_api_client@0.7.6/mod.ts";
+import { OAuthV2AccessResponse } from "https://deno.land/x/slack_web_api_client@0.8.0/mod.ts";
 
 export interface Installation {
   app_id: string;

--- a/src_deno/oidc/callback.ts
+++ b/src_deno/oidc/callback.ts
@@ -2,8 +2,8 @@ import { SlackLoggingLevel } from "../app-env.ts";
 import {
   OpenIDConnectTokenResponse,
   SlackAPIClient,
-} from "https://deno.land/x/slack_web_api_client@0.7.6/mod.ts";
-import { prettyPrint } from "https://deno.land/x/slack_web_api_client@0.7.6/mod.ts";
+} from "https://deno.land/x/slack_web_api_client@0.8.0/mod.ts";
+import { prettyPrint } from "https://deno.land/x/slack_web_api_client@0.8.0/mod.ts";
 
 export interface OpenIDConnectCallbackArgs {
   env: SlackLoggingLevel;

--- a/src_deno/oidc/login.ts
+++ b/src_deno/oidc/login.ts
@@ -1,7 +1,7 @@
 import {
   OpenIDConnectTokenResponse,
   OpenIDConnectUserInfoResponse,
-} from "https://deno.land/x/slack_web_api_client@0.7.6/mod.ts";
+} from "https://deno.land/x/slack_web_api_client@0.8.0/mod.ts";
 
 export interface Login {
   enterprise_id?: string;

--- a/src_deno/request/payload/block-action.ts
+++ b/src_deno/request/payload/block-action.ts
@@ -5,7 +5,7 @@ import {
   MessageAttachment,
   MessageMetadata,
   PlainTextField,
-} from "https://deno.land/x/slack_web_api_client@0.7.6/mod.ts";
+} from "https://deno.land/x/slack_web_api_client@0.8.0/mod.ts";
 import { DataSubmissionView, ViewStateValue } from "./view-objects.ts";
 import { BotProfile } from "./event.ts";
 

--- a/src_deno/request/payload/block-suggestion.ts
+++ b/src_deno/request/payload/block-suggestion.ts
@@ -1,4 +1,4 @@
-import { AnyOption } from "https://deno.land/x/slack_web_api_client@0.7.6/mod.ts";
+import { AnyOption } from "https://deno.land/x/slack_web_api_client@0.8.0/mod.ts";
 import { DataSubmissionView } from "./view-objects.ts";
 
 export interface BlockSuggestion {

--- a/src_deno/request/payload/event.ts
+++ b/src_deno/request/payload/event.ts
@@ -3,7 +3,7 @@ import {
   HomeTabView,
   MessageAttachment,
   MessageMetadata,
-} from "https://deno.land/x/slack_web_api_client@0.7.6/mod.ts";
+} from "https://deno.land/x/slack_web_api_client@0.8.0/mod.ts";
 
 export type AnySlackEvent =
   | AppRequestedEvent

--- a/src_deno/request/payload/view-objects.ts
+++ b/src_deno/request/payload/view-objects.ts
@@ -3,7 +3,7 @@ import {
   AnyModalBlock,
   PlainTextField,
   RichTextBlock,
-} from "https://deno.land/x/slack_web_api_client@0.7.6/mod.ts";
+} from "https://deno.land/x/slack_web_api_client@0.8.0/mod.ts";
 
 export interface ViewStateSelectedOption {
   text: PlainTextField;

--- a/src_deno/response/response-body.ts
+++ b/src_deno/response/response-body.ts
@@ -4,7 +4,7 @@ import {
   MessageAttachment,
   MessageMetadata,
   ModalView,
-} from "https://deno.land/x/slack_web_api_client@0.7.6/mod.ts";
+} from "https://deno.land/x/slack_web_api_client@0.8.0/mod.ts";
 
 export interface MessageResponse {
   response_type?: "ephemeral" | "in_channel";

--- a/src_deno/socket-mode/payload-handler.ts
+++ b/src_deno/socket-mode/payload-handler.ts
@@ -1,0 +1,49 @@
+interface fromSocketModeToRequestArgs {
+  url?: string;
+  body: Record<string, unknown>;
+  retryNum?: string;
+  retryReason?: string;
+}
+export function fromSocketModeToRequest({
+  url,
+  body,
+  retryNum,
+  retryReason,
+}: fromSocketModeToRequestArgs): Request {
+  const payload = JSON.stringify(body);
+  const headers: Record<string, string> = {
+    "content-type": "application/json",
+  };
+  if (retryNum) {
+    headers["x-slack-retry-num"] = retryNum;
+  }
+  if (retryReason) {
+    headers["x-slack-retry-reason"] = retryReason;
+  }
+  const options = {
+    method: "POST",
+    headers: new Headers(headers),
+    body: new Blob([payload]).stream(),
+    duplex: "half", // required when running on Node.js runtime
+  };
+  return new Request(url ?? "wss://localhost", options);
+}
+
+interface fromResponseToSocketModePayloadArgs {
+  response: Response;
+}
+export async function fromResponseToSocketModePayload({
+  response,
+}: fromResponseToSocketModePayloadArgs): Promise<Record<string, unknown>> {
+  let message: Record<string, unknown> = {};
+  if (response.body) {
+    const contentType = response.headers.get("Content-Type");
+    if (contentType && contentType.startsWith("text/plain")) {
+      const text = await response.text();
+      message = { text };
+    } else {
+      message = await response.json();
+    }
+  }
+  return message;
+}

--- a/test/node-socket-mode/.gitignore
+++ b/test/node-socket-mode/.gitignore
@@ -1,0 +1,6 @@
+node_modules/
+lib/
+.env
+.vscode/
+data/
+package-lock.json

--- a/test/node-socket-mode/package.json
+++ b/test/node-socket-mode/package.json
@@ -1,0 +1,21 @@
+{
+  "name": "node-socket-mode-test",
+  "version": "1.0.0",
+  "description": "",
+  "main": "lib/index.js",
+  "scripts": {
+    "start": "npm run build:live",
+    "build": "tsc -p .",
+    "build:live": "nodemon --watch 'src/**/*.ts' --exec \"ts-node\" src/main.ts"
+  },
+  "author": "",
+  "license": "MIT",
+  "dependencies": {
+    "@slack/socket-mode": "^1.3.3",
+    "@types/node": "^20.11.6",
+    "nodemon": "^3.0.3",
+    "slack-edge": "^0.9.3",
+    "ts-node": "^10.9.2",
+    "typescript": "^5.3.3"
+  }
+}

--- a/test/node-socket-mode/src/main.ts
+++ b/test/node-socket-mode/src/main.ts
@@ -1,0 +1,43 @@
+import { SocketModeClient } from "@slack/socket-mode";
+import { LogLevel } from "@slack/logger";
+import { SlackApp } from "slack-edge";
+import {
+  fromSocketModeToRequest,
+  fromResponseToSocketModePayload,
+} from "./wip";
+
+const app = new SlackApp({
+  socketMode: true,
+  env: {
+    SLACK_BOT_TOKEN: process.env.SLACK_BOT_TOKEN!,
+    SLACK_APP_TOKEN: process.env.SLACK_APP_TOKEN!,
+    SLACK_LOGGING_LEVEL: "DEBUG",
+  },
+});
+app.command("/hello", async ({}) => {
+  return "Hi!";
+});
+app.anyMessage(async ({ context }) => {
+  await context.say({ text: "Hi!" });
+});
+
+(async () => {
+  const socketMode = new SocketModeClient({
+    appToken: process.env.SLACK_APP_TOKEN!,
+    logLevel: LogLevel.DEBUG,
+  });
+  socketMode.on(
+    "slack_event",
+    async ({ body, ack, retry_num, retry_reason }) => {
+      const response = await app.run(
+        fromSocketModeToRequest({
+          body,
+          retryNum: retry_num,
+          retryReason: retry_reason,
+        }),
+      );
+      await ack(await fromResponseToSocketModePayload({ response }));
+    },
+  );
+  await socketMode.start();
+})();

--- a/test/node-socket-mode/src/wip.ts
+++ b/test/node-socket-mode/src/wip.ts
@@ -1,0 +1,51 @@
+import { ExecutionContext } from "slack-edge";
+
+interface fromSocketModeToRequestArgs {
+  url?: string;
+  body: Record<string, unknown>;
+  retryNum?: string;
+  retryReason?: string;
+}
+export function fromSocketModeToRequest({
+  url,
+  body,
+  retryNum,
+  retryReason,
+}: fromSocketModeToRequestArgs): Request {
+  const payload = JSON.stringify(body);
+  const headers: Record<string, string> = {
+    "content-type": "application/json",
+  };
+  if (retryNum) {
+    headers["x-slack-retry-num"] = retryNum;
+  }
+  if (retryReason) {
+    headers["x-slack-retry-reason"] = retryReason;
+  }
+  const options = {
+    method: "POST",
+    headers: new Headers(headers),
+    body: new Blob([payload]).stream(),
+    duplex: "half", // required when running on Node.js runtime
+  };
+  return new Request(url ?? "wss://localhost", options);
+}
+
+interface fromResponseToSocketModePayloadArgs {
+  response: Response;
+}
+export async function fromResponseToSocketModePayload({
+  response,
+}: fromResponseToSocketModePayloadArgs): Promise<Record<string, unknown>> {
+  let message: Record<string, unknown> = {};
+  if (response.body) {
+    const contentType = response.headers.get("Content-Type");
+    if (contentType && contentType.startsWith("text/plain")) {
+      const text = await response.text();
+      message = { text };
+    } else {
+      message = await response.json();
+    }
+  }
+  return message;
+}

--- a/test/node-socket-mode/tsconfig.json
+++ b/test/node-socket-mode/tsconfig.json
@@ -1,0 +1,12 @@
+{
+  "compilerOptions": {
+    "target": "es5",
+    "module": "commonjs",
+    "lib": ["es6", "dom"],
+    "outDir": "lib",
+    "rootDir": "src",
+    "strict": true,
+    "esModuleInterop": true,
+    "resolveJsonModule": true,
+  },
+}


### PR DESCRIPTION
This pull request adds the modules that enable developers to use `@slack/socket-mode` library along with slack-edge for stable Socket Mode operations.