### PR TITLE
update user object types for team_join event

### DIFF
--- a/src/request/payload/event.ts
+++ b/src/request/payload/event.ts
@@ -775,7 +775,75 @@ export interface TeamDomainChangedEvent
 
 export interface TeamJoinEvent extends SlackEvent<"team_join"> {
   type: "team_join";
-  user: { id: string };
+  user: {
+    id: string;
+    team_id: string;
+    name: string;
+    deleted: boolean;
+    color: string;
+    real_name: string;
+    tz: string;
+    tz_label: string;
+    tz_offset: number;
+    profile: {
+      title: string;
+      phone: string;
+      skype: string;
+      real_name: string;
+      real_name_normalized: string;
+      display_name: string;
+      display_name_normalized: string;
+      status_text: string;
+      status_text_canonical: string;
+      status_emoji: string;
+      status_emoji_display_info: StatusEmojiDisplayInfo[];
+      status_expiration: number;
+      avatar_hash: string;
+      huddle_state?: string;
+      huddle_state_expiration_ts?: number;
+      bot_id?: string;
+      first_name: string;
+      last_name: string;
+      email?: string;
+      image_original?: string;
+      is_custom_image?: boolean;
+      image_24: string;
+      image_32: string;
+      image_48: string;
+      image_72: string;
+      image_192: string;
+      image_512: string;
+      image_1024?: string;
+      team: string;
+      fields: { [key: string]: { value: string; alt: string } } | [] | null;
+    };
+    is_admin: boolean;
+    is_owner: boolean;
+    is_primary_owner: boolean;
+    is_restricted: boolean;
+    is_ultra_restricted: boolean;
+    is_bot: boolean;
+    is_stranger?: boolean;
+    updated: number;
+    is_email_confirmed: boolean;
+    is_app_user: boolean;
+    is_invited_user?: boolean;
+    has_2fa?: boolean;
+    locale: string;
+    presence?: string;
+    enterprise_user?: {
+      id: string;
+      enterprise_id: string;
+      enterprise_name: string;
+      is_admin: boolean;
+      is_owner: boolean;
+      teams: string[];
+    };
+    two_factor_type?: string;
+    has_files?: boolean;
+    is_workflow_bot?: boolean;
+    who_can_share_contact_card: string;
+  };
 }
 
 export interface TeamRenameEvent extends SlackEvent<"team_rename"> {

--- a/src_deno/request/payload/event.ts
+++ b/src_deno/request/payload/event.ts
@@ -775,7 +775,75 @@ export interface TeamDomainChangedEvent
 
 export interface TeamJoinEvent extends SlackEvent<"team_join"> {
   type: "team_join";
-  user: { id: string };
+  user: {
+    id: string;
+    team_id: string;
+    name: string;
+    deleted: boolean;
+    color: string;
+    real_name: string;
+    tz: string;
+    tz_label: string;
+    tz_offset: number;
+    profile: {
+      title: string;
+      phone: string;
+      skype: string;
+      real_name: string;
+      real_name_normalized: string;
+      display_name: string;
+      display_name_normalized: string;
+      status_text: string;
+      status_text_canonical: string;
+      status_emoji: string;
+      status_emoji_display_info: StatusEmojiDisplayInfo[];
+      status_expiration: number;
+      avatar_hash: string;
+      huddle_state?: string;
+      huddle_state_expiration_ts?: number;
+      bot_id?: string;
+      first_name: string;
+      last_name: string;
+      email?: string;
+      image_original?: string;
+      is_custom_image?: boolean;
+      image_24: string;
+      image_32: string;
+      image_48: string;
+      image_72: string;
+      image_192: string;
+      image_512: string;
+      image_1024?: string;
+      team: string;
+      fields: { [key: string]: { value: string; alt: string } } | [] | null;
+    };
+    is_admin: boolean;
+    is_owner: boolean;
+    is_primary_owner: boolean;
+    is_restricted: boolean;
+    is_ultra_restricted: boolean;
+    is_bot: boolean;
+    is_stranger?: boolean;
+    updated: number;
+    is_email_confirmed: boolean;
+    is_app_user: boolean;
+    is_invited_user?: boolean;
+    has_2fa?: boolean;
+    locale: string;
+    presence?: string;
+    enterprise_user?: {
+      id: string;
+      enterprise_id: string;
+      enterprise_name: string;
+      is_admin: boolean;
+      is_owner: boolean;
+      teams: string[];
+    };
+    two_factor_type?: string;
+    has_files?: boolean;
+    is_workflow_bot?: boolean;
+    who_can_share_contact_card: string;
+  };
 }
 
 export interface TeamRenameEvent extends SlackEvent<"team_rename"> {


### PR DESCRIPTION
# Changes
Expanding the typing for the `user` object of the `team_join` event.

# Ref
Example bot `team_join` event:
```
{
  "type": "team_join",
  "user": {
    "id": "U06KVUU32P6",
    "team_id": "T060SL2GMU6",
    "name": "channeltools",
    "deleted": false,
    "color": "a2a5dc",
    "real_name": "Channel Tools",
    "tz": "America/Los_Angeles",
    "tz_label": "Pacific Standard Time",
    "tz_offset": -28800,
    "profile": {
      "title": "",
      "phone": "",
      "skype": "",
      "real_name": "Channel Tools",
      "real_name_normalized": "Channel Tools",
      "display_name": "",
      "display_name_normalized": "",
      "fields": {},
      "status_text": "",
      "status_emoji": "",
      "status_emoji_display_info": [],
      "status_expiration": 0,
      "avatar_hash": "g23d05fa5f0f",
      "api_app_id": "A018HK8FDB5",
      "always_active": true,
      "bot_id": "B06L659TLHX",
      "first_name": "Channel",
      "last_name": "Tools",
      "image_24": "https://secure.gravatar.com/avatar/23d05fa5f0fb6bcecc93eae5aea7ba7b.jpg?s=24&d=https%3A%2F%2Fa.slack-edge.com%2Fdf10d%2Fimg%2Favatars%2Fava_0001-24.png",
      "image_32": "https://secure.gravatar.com/avatar/23d05fa5f0fb6bcecc93eae5aea7ba7b.jpg?s=32&d=https%3A%2F%2Fa.slack-edge.com%2Fdf10d%2Fimg%2Favatars%2Fava_0001-32.png",
      "image_48": "https://secure.gravatar.com/avatar/23d05fa5f0fb6bcecc93eae5aea7ba7b.jpg?s=48&d=https%3A%2F%2Fa.slack-edge.com%2Fdf10d%2Fimg%2Favatars%2Fava_0001-48.png",
      "image_72": "https://secure.gravatar.com/avatar/23d05fa5f0fb6bcecc93eae5aea7ba7b.jpg?s=72&d=https%3A%2F%2Fa.slack-edge.com%2Fdf10d%2Fimg%2Favatars%2Fava_0001-72.png",
      "image_192": "https://secure.gravatar.com/avatar/23d05fa5f0fb6bcecc93eae5aea7ba7b.jpg?s=192&d=https%3A%2F%2Fa.slack-edge.com%2Fdf10d%2Fimg%2Favatars%2Fava_0001-192.png",
      "image_512": "https://secure.gravatar.com/avatar/23d05fa5f0fb6bcecc93eae5aea7ba7b.jpg?s=512&d=https%3A%2F%2Fa.slack-edge.com%2Fdf10d%2Fimg%2Favatars%2Fava_0001-512.png",
      "status_text_canonical": "",
      "team": "T060SL2GMU6"
    },
    "is_admin": false,
    "is_owner": false,
    "is_primary_owner": false,
    "is_restricted": false,
    "is_ultra_restricted": false,
    "is_bot": true,
    "is_app_user": false,
    "updated": 1708470013,
    "is_email_confirmed": false,
    "who_can_share_contact_card": "EVERYONE",
    "presence": "away"
  },
  "cache_ts": 1708470013,
  "event_ts": "1708470013.032000"
}
```