### PR TITLE
Update types for uploaded file dimension fields

### DIFF
--- a/src/request/payload/view-objects.ts
+++ b/src/request/payload/view-objects.ts
@@ -70,8 +70,8 @@ export interface UploadedFile {
   num_stars?: number;
   org_or_workspace_access?: string;
   original_attachment_count?: number;
-  original_h?: string;
-  original_w?: string;
+  original_h?: number;
+  original_w?: number;
   permalink_public?: string;
   pinned_to?: string[];
   pjpeg?: string;

--- a/src_deno/request/payload/event.ts
+++ b/src_deno/request/payload/event.ts
@@ -1793,8 +1793,8 @@ export interface FileItem {
   non_owner_editable?: boolean;
   num_stars?: number;
   original_attachment_count?: number;
-  original_h?: string;
-  original_w?: string;
+  original_h?: number;
+  original_w?: number;
   permalink: string;
   permalink_public?: string;
   pinned_to?: string[];
@@ -2006,8 +2006,8 @@ export interface FileElement {
   non_owner_editable?: boolean;
   num_stars?: number;
   original_attachment_count?: number;
-  original_h?: string;
-  original_w?: string;
+  original_h?: number;
+  original_w?: number;
   permalink: string;
   permalink_public?: string;
   pinned_to?: string[];

--- a/src_deno/request/payload/view-objects.ts
+++ b/src_deno/request/payload/view-objects.ts
@@ -70,8 +70,8 @@ export interface UploadedFile {
   num_stars?: number;
   org_or_workspace_access?: string;
   original_attachment_count?: number;
-  original_h?: string;
-  original_w?: string;
+  original_h?: number;
+  original_w?: number;
   permalink_public?: string;
   pinned_to?: string[];
   pjpeg?: string;


### PR DESCRIPTION
# Change

Update the types of `original_w` and `original_h` fields to be `number` for various slack File-related types.

# Ref

Example `UploadedFile` object when uploading a file via a modal (note `original_w` and `original_h`):
```
{
  id: 'F06KZDE4L2Z',
  created: 1708578780,
  timestamp: 1708578780,
  name: 'screely-1708464493924.png',
  title: 'screely-1708464493924.png',
  mimetype: 'image/png',
  filetype: 'png',
  pretty_type: 'PNG',
  user: ...,
  user_team: ...,
  editable: false,
  size: 2187248,
  mode: 'hosted',
  is_external: false,
  external_type: '',
  is_public: false,
  public_url_shared: false,
  display_as_bot: false,
  username: ...,
  url_private: ...,
  url_private_download: ...,
  media_display_type: 'unknown',
  thumb_...
  original_w: 2654,
  original_h: 1358,
  thumb_tiny: ...,
  permalink: ...,
  permalink_public: ...,
  comments_count: 0,
  shares: {},
  channels: [],
  groups: [],
  ims: [],
  has_more_shares: false,
  has_rich_preview: false,
  file_access: 'visible'
}
```