### PR TITLE
Improve bot-related property types in context object

### DIFF
--- a/src/context/context.ts
+++ b/src/context/context.ts
@@ -14,8 +14,8 @@ export interface PreAuthorizeSlackAppContext {
   actorEnterpriseId?: string;
   actorTeamId?: string;
   actorUserId?: string;
-  botId?: string;
-  botUserId?: string;
+  botId?: string; // this will always exist when initializing SlackAppContext
+  botUserId?: string; // this will always exist when initializing SlackAppContext
   responseUrl?: string;
   channelId?: string;
   triggerId?: string;
@@ -32,6 +32,8 @@ export type Respond = (params: WebhookParams) => Promise<Response>;
 export type SlackAppContext = {
   client: SlackAPIClient;
   botToken: string;
+  botId: string; // this must exist here
+  botUserId: string; // this must exist here
   userToken?: string;
   authorizeResult: AuthorizeResult;
 } & PreAuthorizeSlackAppContext;

--- a/src_deno/context/context.ts
+++ b/src_deno/context/context.ts
@@ -14,8 +14,8 @@ export interface PreAuthorizeSlackAppContext {
   actorEnterpriseId?: string;
   actorTeamId?: string;
   actorUserId?: string;
-  botId?: string;
-  botUserId?: string;
+  botId?: string; // this will always exist when initializing SlackAppContext
+  botUserId?: string; // this will always exist when initializing SlackAppContext
   responseUrl?: string;
   channelId?: string;
   triggerId?: string;
@@ -32,6 +32,8 @@ export type Respond = (params: WebhookParams) => Promise<Response>;
 export type SlackAppContext = {
   client: SlackAPIClient;
   botToken: string;
+  botId: string; // this must exist here
+  botUserId: string; // this must exist here
   userToken?: string;
   authorizeResult: AuthorizeResult;
 } & PreAuthorizeSlackAppContext;

--- a/test/app.test.ts
+++ b/test/app.test.ts
@@ -62,8 +62,11 @@ describe("SlackApp", () => {
     // Events API
     const appMentionEvent: EventLazyHandler<"app_mention"> = async ({
       payload,
+      context,
     }) => {
       const type: "app_mention" = payload.type;
+      const botUserId: string = context.botUserId;
+      const botId: string = context.botId;
     };
     app.event("app_mention", appMentionEvent);
 


### PR DESCRIPTION
This pull request improves the types of botId and botUserId in context object.

- before: string | undefined
- after: string

