### PR TITLE
Update return type in fromHexStringToBytes for Next.js compatibility

### DIFF
--- a/src/request/request-verification.ts
+++ b/src/request/request-verification.ts
@@ -39,5 +39,5 @@ function fromHexStringToBytes(hexString: string) {
   for (let idx = 0; idx < hexString.length; idx += 2) {
     bytes[idx / 2] = parseInt(hexString.substring(idx, idx + 2), 16);
   }
-  return bytes.buffer;
+  return bytes;
 }


### PR DESCRIPTION
issue #24 
## Overview
This PR addresses an issue in the `fromHexStringToBytes` function that was causing errors in Next.js applications. To resolve this, the return type of the function has been changed from `ArrayBufferLike` to  `Uint8Array`.

## Changes
- Changed the return type of `fromHexStringToBytes` from `ArrayBufferLike` to `Uint8Array` to ensure compatibility with Next.js.

## Testing
The function has been tested locally in a Next.js setup and is working as expected. However, tests in environments such as Cloudflare Workers are pending.

Please review the changes and let me know if there are any concerns or additional adjustments needed. Further testing in other environments will be conducted as needed.