### PR TITLE
Add ignoreSelfAssistantMessageEvents and Assistant#botMessageHandler

### DIFF
--- a/src/assistant/thread-context-store.ts
+++ b/src/assistant/thread-context-store.ts
@@ -33,25 +33,29 @@ export class DefaultAssistantThreadContextStore implements AssistantThreadContex
   }
 
   async #findFirstAssistantReply(key: AssistantThreadKey): Promise<FirstReply | undefined> {
-    const response = await this.#client.conversations.replies({
-      channel: key.channel_id,
-      ts: key.thread_ts,
-      oldest: key.thread_ts,
-      include_all_metadata: true,
-      limit: 4,
-    });
-    if (response.messages) {
-      for (const message of response.messages) {
-        if (!("subtype" in message) && message.user === this.#thisBotUserId) {
-          return {
-            channel_id: key.channel_id,
-            ts: message.ts!,
-            text: message.text!,
-            blocks: message.blocks!,
-            metadata: message.metadata as MessageMetadata | undefined,
-          };
+    try {
+      const response = await this.#client.conversations.replies({
+        channel: key.channel_id,
+        ts: key.thread_ts,
+        oldest: key.thread_ts,
+        include_all_metadata: true,
+        limit: 4,
+      });
+      if (response.messages) {
+        for (const message of response.messages) {
+          if (!("subtype" in message) && message.user === this.#thisBotUserId) {
+            return {
+              channel_id: key.channel_id,
+              ts: message.ts!,
+              text: message.text!,
+              blocks: message.blocks!,
+              metadata: message.metadata as MessageMetadata | undefined,
+            };
+          }
         }
       }
+    } catch (e) {
+      console.log(`Failed to fetch conversations.replies API result: ${e}`);
     }
     return undefined;
   }

--- a/src/handler/handler.ts
+++ b/src/handler/handler.ts
@@ -80,10 +80,12 @@ export type AssistantEventLazyHandler<
   E extends SlackAppEnv = SlackAppEnv,
 > = (req: AssistantThreadEventRequest<E, Type>) => Promise<void>;
 
-export type AssistantMessageEventRequest<E extends SlackAppEnv> = SlackRequestWithAssistantUtilities<
+export type AssistantUserMessageEventRequest<E extends SlackAppEnv> = SlackRequestWithAssistantUtilities<
   E,
   GenericMessageEvent | FileShareMessageEvent
 >;
+
+export type AssistantBotMessageEventRequest<E extends SlackAppEnv> = SlackRequestWithAssistantUtilities<E, GenericMessageEvent>;
 
 // ----------------------------------------
 // Shortcuts

--- a/src/middleware/built-in-middleware.ts
+++ b/src/middleware/built-in-middleware.ts
@@ -19,14 +19,22 @@ const eventTypesToKeep = ["member_joined_channel", "member_left_channel"];
  * @param req request
  * @returns response if needed
  */
-// deno-lint-ignore require-await
-export const ignoringSelfEvents: Middleware = async (req) => {
-  if (req.body.event) {
-    if (eventTypesToKeep.includes(req.body.event.type)) {
-      return;
+export function ignoringSelfEvents(ignoreSelfAssistantMessageEvents: boolean): Middleware {
+  // deno-lint-ignore require-await
+  return async (req) => {
+    if (req.body.event) {
+      if (eventTypesToKeep.includes(req.body.event.type)) {
+        return;
+      }
+      const auth = req.context.authorizeResult;
+      const isSelfEvent = auth.botId === req.body.event.bot_id || auth.botUserId === req.context.userId;
+      if (isSelfEvent) {
+        if (ignoreSelfAssistantMessageEvents && req.body.event.type === "message" && req.body.event.channel_type === "im") {
+          // Assistant#botMessage handles this pattern
+          return;
+        }
+        return { status: 200, body: "" };
+      }
     }
-    if (req.context.authorizeResult.botId === req.body.event.bot_id || req.context.authorizeResult.botUserId === req.context.userId) {
-      return { status: 200, body: "" };
-    }
-  }
-};
+  };
+}

--- a/src/middleware/built-in-middleware.ts
+++ b/src/middleware/built-in-middleware.ts
@@ -29,7 +29,7 @@ export function ignoringSelfEvents(ignoreSelfAssistantMessageEvents: boolean): M
       const auth = req.context.authorizeResult;
       const isSelfEvent = auth.botId === req.body.event.bot_id || auth.botUserId === req.context.userId;
       if (isSelfEvent) {
-        if (ignoreSelfAssistantMessageEvents && req.body.event.type === "message" && req.body.event.channel_type === "im") {
+        if (!ignoreSelfAssistantMessageEvents && req.body.event.type === "message" && req.body.event.channel_type === "im") {
           // Assistant#botMessage handles this pattern
           return;
         }

--- a/src/request/payload/event.ts
+++ b/src/request/payload/event.ts
@@ -1343,6 +1343,7 @@ export type AnyMessageEvent =
   | GenericMessageEvent
   | BotMessageEvent
   | ChannelArchiveMessageEvent
+  | ChannelConvertToPublicessageEvent
   | ChannelJoinMessageEvent
   | ChannelLeaveMessageEvent
   | ChannelNameMessageEvent
@@ -1394,6 +1395,7 @@ export interface GenericMessageEvent extends SlackEvent<"message"> {
   attachments?: MessageAttachment[];
   blocks?: AnyMessageBlock[];
   files?: FileElement[];
+  metadata?: MessageMetadata;
   edited?: {
     user: string;
     ts: string;
@@ -1430,6 +1432,7 @@ export interface BotMessageEvent extends SlackEvent<"message"> {
   user?: string;
   attachments?: MessageAttachment[];
   blocks?: AnyMessageBlock[];
+  metadata?: MessageMetadata;
   edited?: {
     user: string;
     ts: string;
@@ -1497,6 +1500,17 @@ export interface ChannelPostingPermissionsMessageEvent extends SlackEvent<"messa
   text: string;
   ts: string;
   event_ts: string;
+}
+
+export interface ChannelConvertToPublicessageEvent extends SlackEvent<"message"> {
+  type: "message";
+  subtype: "channel_convert_to_public";
+  ts: string;
+  text: string;
+  user: string;
+  channel: string;
+  event_ts: string;
+  channel_type: string;
 }
 
 export interface ChannelPurposeMessageEvent extends SlackEvent<"message"> {

--- a/src_deno/app.ts
+++ b/src_deno/app.ts
@@ -135,6 +135,12 @@ export interface SlackAppOptions<
   ignoreSelfEvents?: boolean;
 
   /**
+   * When this is set to false, the built-in ignoringSelfEvents middleware does not block this app's assistant bot message event.
+   * The default is set to true.
+   */
+  ignoreSelfAssistantMessageEvents?: boolean;
+
+  /**
    * Your custom assistant thread context store implementation.
    */
   assistantThreadContextStore?: AssistantThreadContextStore;
@@ -294,7 +300,10 @@ export class SlackApp<E extends SlackEdgeAppEnv | SlackSocketModeAppEnv> {
     this.startLazyListenerAfterAck = options.startLazyListenerAfterAck ?? false;
     this.ignoreSelfEvents = options.ignoreSelfEvents ?? true;
     if (this.ignoreSelfEvents) {
-      this.postAuthorizeMiddleware.push(ignoringSelfEvents);
+      const middleware = ignoringSelfEvents(
+        options.ignoreSelfAssistantMessageEvents ?? true,
+      );
+      this.postAuthorizeMiddleware.push(middleware);
     }
     this.authorize = options.authorize ?? singleTeamAuthorize;
     this.routes = { events: options.routes?.events };
@@ -434,14 +443,31 @@ export class SlackApp<E extends SlackEdgeAppEnv | SlackSocketModeAppEnv> {
   #assistantEvent<Type extends AnyEventType>(
     event: Type,
     lazy: EventLazyHandler<Type, E>,
+    handleSelfBotMessageEvents: boolean = false,
   ): SlackApp<E> {
     this.#events.push((body) => {
       if (body.type !== PayloadType.EventsAPI || !body.event) {
         return null;
       }
       if (body.event.type === event && isAssitantThreadEvent(body)) {
-        // deno-lint-ignore require-await
-        return { ack: async () => "", lazy };
+        if (event === "message" && "bot_profile" in body.event) {
+          if (handleSelfBotMessageEvents) {
+            // this app's bot message events
+            // The botMessageHandler acknowledges this pattern
+            // Note that ignoreSelfAssistantMessageEvents must be set to false
+            // deno-lint-ignore require-await
+            return { ack: async () => "", lazy };
+          } else {
+            // userMessageHandler does not acknowledge
+            return null;
+          }
+        } else {
+          // assistant_thread_started events
+          // assistant_thread_context_changed events
+          // user message events
+          // deno-lint-ignore require-await
+          return { ack: async () => "", lazy };
+        }
       }
       return null;
     });
@@ -457,7 +483,8 @@ export class SlackApp<E extends SlackEdgeAppEnv | SlackSocketModeAppEnv> {
       "assistant_thread_context_changed",
       assistant.threadContextChangedHandler,
     );
-    this.#assistantEvent("message", assistant.userMessageHandler);
+    this.#assistantEvent("message", assistant.userMessageHandler, false);
+    this.#assistantEvent("message", assistant.botMessageHandler, true);
     if (assistant.threadContextStore) {
       this.assistantThreadContextStore = assistant.threadContextStore;
     }

--- a/src_deno/assistant/assistant.ts
+++ b/src_deno/assistant/assistant.ts
@@ -1,9 +1,10 @@
 import { SlackAppEnv } from "../app-env.ts";
 import { isAssitantThreadEvent } from "../context/context.ts";
 import {
+  AssistantBotMessageEventRequest,
   AssistantEventLazyHandler,
-  AssistantMessageEventRequest,
   AssistantThreadEventRequest,
+  AssistantUserMessageEventRequest,
   EventLazyHandler,
 } from "../handler/handler.ts";
 import {
@@ -19,7 +20,11 @@ export type AssistantThreadContextChangedHandler<E extends SlackAppEnv> =
   AssistantEventLazyHandler<AssistantThreadContextChangedEvent, E>;
 
 export type AssistantUserMessageHandler<E extends SlackAppEnv> = (
-  req: AssistantMessageEventRequest<E>,
+  req: AssistantUserMessageEventRequest<E>,
+) => Promise<void>;
+
+export type AssistantBotMessageHandler<E extends SlackAppEnv> = (
+  req: AssistantBotMessageEventRequest<E>,
 ) => Promise<void>;
 
 export interface AssistantOptions<E extends SlackAppEnv> {
@@ -27,7 +32,7 @@ export interface AssistantOptions<E extends SlackAppEnv> {
   threadStarted?: AssistantThreadStartedHandler<E>;
   threadContextChanged?: AssistantThreadContextChangedHandler<E>;
   userMessage?: AssistantUserMessageHandler<E>;
-  botMessage?: AssistantUserMessageHandler<E>;
+  botMessage?: AssistantBotMessageHandler<E>;
 }
 
 export class Assistant<E extends SlackAppEnv> {
@@ -100,7 +105,9 @@ export class Assistant<E extends SlackAppEnv> {
           req.payload.subtype === "file_share"
         ) {
           if (options.userMessage) {
-            await options.userMessage(req as AssistantMessageEventRequest<E>);
+            await options.userMessage(
+              req as AssistantUserMessageEventRequest<E>,
+            );
           } else {
             // noop; just ack the request
           }
@@ -116,12 +123,11 @@ export class Assistant<E extends SlackAppEnv> {
     this.botMessageHandler = async (req) => {
       try {
         if (
-          (req.payload.subtype === undefined ||
-            req.payload.subtype === "file_share") &&
+          req.payload.subtype === undefined &&
           req.payload.user === req.context.botUserId
         ) {
           if (options.botMessage) {
-            await options.botMessage(req as AssistantMessageEventRequest<E>);
+            await options.botMessage(req as AssistantBotMessageEventRequest<E>);
           } else {
             // noop; just ack the request
           }
@@ -181,7 +187,7 @@ export class Assistant<E extends SlackAppEnv> {
           req.payload.subtype === undefined ||
           req.payload.subtype === "file_share"
         ) {
-          await handler(req as AssistantMessageEventRequest<E>);
+          await handler(req as AssistantUserMessageEventRequest<E>);
         }
       } catch (e: unknown) {
         console.error(
@@ -192,15 +198,14 @@ export class Assistant<E extends SlackAppEnv> {
       }
     };
   }
-  botMessage(handler: AssistantUserMessageHandler<E>) {
+  botMessage(handler: AssistantBotMessageHandler<E>) {
     this.botMessageHandler = async (req) => {
       try {
         if (
-          (req.payload.subtype === undefined ||
-            req.payload.subtype === "file_share") &&
+          req.payload.subtype === undefined &&
           req.payload.user === req.context.botUserId
         ) {
-          await handler(req as AssistantMessageEventRequest<E>);
+          await handler(req as AssistantBotMessageEventRequest<E>);
         }
       } catch (e: unknown) {
         console.error(

--- a/src_deno/assistant/thread-context-store.ts
+++ b/src_deno/assistant/thread-context-store.ts
@@ -45,25 +45,29 @@ export class DefaultAssistantThreadContextStore
   async #findFirstAssistantReply(
     key: AssistantThreadKey,
   ): Promise<FirstReply | undefined> {
-    const response = await this.#client.conversations.replies({
-      channel: key.channel_id,
-      ts: key.thread_ts,
-      oldest: key.thread_ts,
-      include_all_metadata: true,
-      limit: 4,
-    });
-    if (response.messages) {
-      for (const message of response.messages) {
-        if (!("subtype" in message) && message.user === this.#thisBotUserId) {
-          return {
-            channel_id: key.channel_id,
-            ts: message.ts!,
-            text: message.text!,
-            blocks: message.blocks!,
-            metadata: message.metadata as MessageMetadata | undefined,
-          };
+    try {
+      const response = await this.#client.conversations.replies({
+        channel: key.channel_id,
+        ts: key.thread_ts,
+        oldest: key.thread_ts,
+        include_all_metadata: true,
+        limit: 4,
+      });
+      if (response.messages) {
+        for (const message of response.messages) {
+          if (!("subtype" in message) && message.user === this.#thisBotUserId) {
+            return {
+              channel_id: key.channel_id,
+              ts: message.ts!,
+              text: message.text!,
+              blocks: message.blocks!,
+              metadata: message.metadata as MessageMetadata | undefined,
+            };
+          }
         }
       }
+    } catch (e) {
+      console.log(`Failed to fetch conversations.replies API result: ${e}`);
     }
     return undefined;
   }

--- a/src_deno/handler/handler.ts
+++ b/src_deno/handler/handler.ts
@@ -98,11 +98,14 @@ export type AssistantEventLazyHandler<
   E extends SlackAppEnv = SlackAppEnv,
 > = (req: AssistantThreadEventRequest<E, Type>) => Promise<void>;
 
-export type AssistantMessageEventRequest<E extends SlackAppEnv> =
+export type AssistantUserMessageEventRequest<E extends SlackAppEnv> =
   SlackRequestWithAssistantUtilities<
     E,
     GenericMessageEvent | FileShareMessageEvent
   >;
+
+export type AssistantBotMessageEventRequest<E extends SlackAppEnv> =
+  SlackRequestWithAssistantUtilities<E, GenericMessageEvent>;
 
 // ----------------------------------------
 // Shortcuts

--- a/src_deno/middleware/built-in-middleware.ts
+++ b/src_deno/middleware/built-in-middleware.ts
@@ -33,7 +33,7 @@ export function ignoringSelfEvents(
         auth.botUserId === req.context.userId;
       if (isSelfEvent) {
         if (
-          ignoreSelfAssistantMessageEvents &&
+          !ignoreSelfAssistantMessageEvents &&
           req.body.event.type === "message" &&
           req.body.event.channel_type === "im"
         ) {

--- a/src_deno/middleware/built-in-middleware.ts
+++ b/src_deno/middleware/built-in-middleware.ts
@@ -19,17 +19,29 @@ const eventTypesToKeep = ["member_joined_channel", "member_left_channel"];
  * @param req request
  * @returns response if needed
  */
-// deno-lint-ignore require-await
-export const ignoringSelfEvents: Middleware = async (req) => {
-  if (req.body.event) {
-    if (eventTypesToKeep.includes(req.body.event.type)) {
-      return;
+export function ignoringSelfEvents(
+  ignoreSelfAssistantMessageEvents: boolean,
+): Middleware {
+  // deno-lint-ignore require-await
+  return async (req) => {
+    if (req.body.event) {
+      if (eventTypesToKeep.includes(req.body.event.type)) {
+        return;
+      }
+      const auth = req.context.authorizeResult;
+      const isSelfEvent = auth.botId === req.body.event.bot_id ||
+        auth.botUserId === req.context.userId;
+      if (isSelfEvent) {
+        if (
+          ignoreSelfAssistantMessageEvents &&
+          req.body.event.type === "message" &&
+          req.body.event.channel_type === "im"
+        ) {
+          // Assistant#botMessage handles this pattern
+          return;
+        }
+        return { status: 200, body: "" };
+      }
     }
-    if (
-      req.context.authorizeResult.botId === req.body.event.bot_id ||
-      req.context.authorizeResult.botUserId === req.context.userId
-    ) {
-      return { status: 200, body: "" };
-    }
-  }
-};
+  };
+}

--- a/src_deno/request/payload/event.ts
+++ b/src_deno/request/payload/event.ts
@@ -1378,6 +1378,7 @@ export type AnyMessageEvent =
   | GenericMessageEvent
   | BotMessageEvent
   | ChannelArchiveMessageEvent
+  | ChannelConvertToPublicessageEvent
   | ChannelJoinMessageEvent
   | ChannelLeaveMessageEvent
   | ChannelNameMessageEvent
@@ -1432,6 +1433,7 @@ export interface GenericMessageEvent extends SlackEvent<"message"> {
   attachments?: MessageAttachment[];
   blocks?: AnyMessageBlock[];
   files?: FileElement[];
+  metadata?: MessageMetadata;
   edited?: {
     user: string;
     ts: string;
@@ -1468,6 +1470,7 @@ export interface BotMessageEvent extends SlackEvent<"message"> {
   user?: string;
   attachments?: MessageAttachment[];
   blocks?: AnyMessageBlock[];
+  metadata?: MessageMetadata;
   edited?: {
     user: string;
     ts: string;
@@ -1536,6 +1539,18 @@ export interface ChannelPostingPermissionsMessageEvent
   text: string;
   ts: string;
   event_ts: string;
+}
+
+export interface ChannelConvertToPublicessageEvent
+  extends SlackEvent<"message"> {
+  type: "message";
+  subtype: "channel_convert_to_public";
+  ts: string;
+  text: string;
+  user: string;
+  channel: string;
+  event_ts: string;
+  channel_type: string;
 }
 
 export interface ChannelPurposeMessageEvent extends SlackEvent<"message"> {

--- a/test/node-socket-mode/package.json
+++ b/test/node-socket-mode/package.json
@@ -13,8 +13,8 @@
   "author": "Kazuhiro Sera",
   "license": "MIT",
   "dependencies": {
-    "@slack/socket-mode": "^1.3.3",
-    "slack-edge": "^1.0.3"
+    "@slack/socket-mode": "^2.0.1",
+    "slack-edge": "^1.1.1"
   },
   "devDependencies": {
     "@slack/cli-hooks": "^1.0.0",

--- a/test/node-socket-mode/src/app.ts
+++ b/test/node-socket-mode/src/app.ts
@@ -1,10 +1,15 @@
-import { SlackApp, Assistant } from "../../../src/index"; // "slack-edge"
+import {
+  SlackApp,
+  SlackAPIError,
+  AssistantThreadContext,
+} from "../../../src/index"; // "slack-edge"
 
 type LogLevel = "DEBUG" | "INFO" | "WARN" | "ERROR";
 const logLevel = (process.env.SLACK_APP_LOG_LEVEL || "DEBUG") as LogLevel;
 
 export const app = new SlackApp({
   socketMode: true,
+  ignoreSelfAssistantMessageEvents: false,
   env: {
     SLACK_BOT_TOKEN: process.env.SLACK_BOT_TOKEN!,
     SLACK_APP_TOKEN: process.env.SLACK_APP_TOKEN!,
@@ -12,26 +17,164 @@ export const app = new SlackApp({
   },
 });
 
-app.assistant(new Assistant({
-  threadStarted: async ({ context: { say, setSuggestedPrompts }}) => {
-    await say({ text: "Hello, how can I help you today?"});
-    await setSuggestedPrompts({
-      title: "New chat",
-      prompts: [
-        "What does SLACK stand for?"
-      ]
-    })
-  },
-  userMessage: async ({ context: { setStatus, say, threadContextStore, channelId, threadTs }}) => {
-    await setStatus({ status: "is typing..."});
-    const threadContext = await threadContextStore.find({ channel_id: channelId, thread_ts: threadTs });
+app.assistantThreadStarted(
+  async ({
+    context: { threadContext, say, setSuggestedPrompts, channelId, threadTs },
+  }) => {
     if (threadContext?.channel_id) {
-      await say({ text: `Do you need help with contents in <#${threadContext.channel_id}>?` });
+      await say({
+        text: "Hello, how can I help you today?",
+        blocks: [
+          {
+            type: "section",
+            text: {
+              type: "mrkdwn",
+              text: "Hello, how can I help you today?",
+            },
+          },
+          {
+            type: "actions",
+            elements: [
+              {
+                type: "button",
+                action_id: "assistant-summarize-channel",
+                text: { type: "plain_text", text: "Summarize the channel" },
+                value: JSON.stringify({ channelId, threadTs, threadContext }),
+              },
+              {
+                type: "button",
+                action_id: "assistant-generate-random-numbers",
+                text: { type: "plain_text", text: "Generate random numbers" },
+                value: JSON.stringify({ channelId, threadTs, threadContext }),
+              },
+            ],
+          },
+        ],
+      });
     } else {
-      await say({ text: "Here you are!" });
+      await say({ text: "Hello, how can I help you today?" });
+      await setSuggestedPrompts({
+        title: "New chat",
+        prompts: ["What does SLACK stand for?"],
+      });
     }
-  }
-}));
+  },
+);
+
+app.assistantUserMessage(
+  async ({
+    context: { setStatus, say, threadContextStore, channelId, threadTs },
+  }) => {
+    await setStatus({ status: "is typing..." });
+    const threadContext = await threadContextStore.find({
+      channel_id: channelId,
+      thread_ts: threadTs,
+    });
+    if (threadContext?.channel_id) {
+      await say({
+        text: `OK, I will do more research on <#${threadContext.channel_id}> history, and will update you once it's done!`,
+        metadata: {
+          event_type: "assistant_summarize_channel",
+          event_payload: { ...threadContext },
+        },
+      });
+    } else {
+      await say({
+        text: "Sorry, I couldn't understand your comment. Could you say it in a different way?",
+      });
+    }
+  },
+);
+
+app.assistantBotMessage(
+  async ({ payload, context: { client, setStatus, say } }) => {
+    if (payload.metadata?.event_type === "assistant_summarize_channel") {
+      await setStatus({ status: "is analyzing the channel content..." });
+      const channel = payload.metadata.event_payload.channel_id as string;
+      try {
+        const messages = (
+          await client.conversations.history({ channel, limit: 5 })
+        ).messages;
+        await setStatus({ status: "is working on the summary..." });
+        await new Promise((r) => setTimeout(r, 1000));
+        // TODO: better work with LLM
+        const summary = messages
+          ?.map((m) => m.text?.substring(0, 100) + "...")
+          .join(", ");
+        if (messages) {
+          await say({ text: `Here you are!: ${summary}` });
+        } else {
+          await say({ text: ":warning: Something went wrong!" });
+        }
+      } catch (e: unknown) {
+        if ((e as SlackAPIError).error === "not_in_channel") {
+          await say({
+            text: `:warning: Invite this app's bot user to <#${channel}> first.`,
+          });
+        } else {
+          await say({ text: `:warning: Something went wrong! ${e}` });
+        }
+      }
+    } else if (payload.metadata?.event_type === "assistant_random_numbers") {
+      await setStatus({ status: "is selecting numbers..." });
+      await new Promise((r) => setTimeout(r, 1000));
+      const numbers = "3,10,57,72,89";
+      await say({ text: `Here you are!:\n${numbers}` });
+    } else {
+      // nothing to do; when you enhance here, be careful not to cause infinite loop
+    }
+  },
+);
+
+app.action<"button">(
+  "assistant-summarize-channel",
+  async ({ payload, context: { client } }) => {
+    const threadContext = payload.message!.metadata!
+      .event_payload as unknown as AssistantThreadContext;
+    await client.views.open({
+      trigger_id: payload.trigger_id,
+      view: {
+        type: "modal",
+        title: { type: "plain_text", text: "My Assistant" },
+        close: { type: "plain_text", text: "Close" },
+        blocks: [
+          {
+            type: "section",
+            text: {
+              type: "mrkdwn",
+              text: `Got it! I will start analyzing <#${threadContext.channel_id}>! I will update you once it's done!`,
+            },
+          },
+        ],
+      },
+    });
+    await client.chat.postMessage({
+      channel: payload.channel!.id,
+      thread_ts: payload.message!.thread_ts,
+      text: `OK, I will do more research on <#${threadContext.channel_id}> history, and will update you once it's done!`,
+      metadata: {
+        event_type: "assistant_summarize_channel", // triggers the next operation within botMessage handler
+        event_payload: { ...threadContext },
+      },
+    });
+  },
+);
+app.action<"button">(
+  "assistant-generate-random-numbers",
+  async ({ payload, context: { client } }) => {
+    const threadContext = payload.message!.metadata!
+      .event_payload as unknown as AssistantThreadContext;
+    await client.chat.postMessage({
+      channel: payload.channel!.id,
+      thread_ts: payload.message!.thread_ts,
+      text: "OK, I will generarte random numbers for you!",
+      metadata: {
+        event_type: "assistant_random_numbers", // triggers the next operation within botMessage handler
+        event_payload: { ...threadContext },
+      },
+    });
+  },
+);
 
 app.event(
   "app_home_opened",


### PR DESCRIPTION
This enhancement is useful when an assistant app ...
- the bot places buttons in the first reply (threadStarted -> say)
- and end-user clicks it and submit the modal with inputs (block action -> view submission)
- the bot posts a message with the inputs + message metadata (-> say ...)
- the bot continue LLM-based response right after that (botMessage -> setStatus, say ...)