### PR TITLE
Improve app.action payload type handling

### DIFF
--- a/src/app.ts
+++ b/src/app.ts
@@ -16,6 +16,8 @@ import {
   SlackHandler,
   SlashCommandAckHandler,
   SlashCommandLazyHandler,
+  SourceSpecifiedBlockActionAckHandler,
+  SourceSpecifiedBlockActionLazyHandler,
   ViewAckHandler,
   ViewClosedAckHandler,
   ViewClosedLazyHandler,
@@ -574,8 +576,8 @@ export class SlackApp<E extends SlackEdgeAppEnv | SlackSocketModeAppEnv> {
     A extends BlockAction<Extract<BlockElementActions, { type: T }>> = BlockAction<Extract<BlockElementActions, { type: T }>>,
   >(
     constraints: StringOrRegExp | { type: T; block_id?: string; action_id: string },
-    ack: BlockActionAckHandler<T, E, A>,
-    lazy: BlockActionLazyHandler<T, E, A> = noopLazyHandler,
+    ack: BlockActionAckHandler<T, E, A> | SourceSpecifiedBlockActionAckHandler<E, A>,
+    lazy: BlockActionLazyHandler<T, E, A> | SourceSpecifiedBlockActionLazyHandler<E, A> = noopLazyHandler,
   ): SlackApp<E> {
     const handler: SlackHandler<E, A> = { ack, lazy };
     this.#blockActions.push((body) => {

--- a/src/handler/handler.ts
+++ b/src/handler/handler.ts
@@ -1,7 +1,7 @@
 import { AnyEventType } from "slack-web-api-client";
 import { EventRequest, MessageEventHandler } from "../app";
 import { SlackAppEnv } from "../app-env";
-import { BlockAction, BlockElementActions, BlockElementTypes } from "../request/payload/block-action";
+import { BlockAction, BlockElementAction, BlockElementActions, BlockElementTypes } from "../request/payload/block-action";
 import { BlockSuggestion } from "../request/payload/block-suggestion";
 import { GlobalShortcut } from "../request/payload/global-shortcut";
 import { MessageShortcut } from "../request/payload/message-shortcut";
@@ -143,12 +143,25 @@ export type BlockActionAckHandler<
 > = (req: SlackRequestWithOptionalRespond<E, A>) => Promise<AckResponse>;
 
 /**
+ * ack function for block_actions request handling.
+ */
+export type SourceSpecifiedBlockActionAckHandler<
+  E extends SlackAppEnv = SlackAppEnv,
+  A extends BlockAction<BlockElementAction> = BlockAction<BlockElementAction>,
+> = (req: SlackRequestWithOptionalRespond<E, A>) => Promise<AckResponse>;
+
+/**
  * lazy function for block_actions request handling.
  */
 export type BlockActionLazyHandler<
   T extends BlockElementTypes,
   E extends SlackAppEnv = SlackAppEnv,
   A extends BlockAction<Extract<BlockElementActions, { type: T }>> = BlockAction<Extract<BlockElementActions, { type: T }>>,
+> = (req: SlackRequestWithOptionalRespond<E, A>) => Promise<void>;
+
+export type SourceSpecifiedBlockActionLazyHandler<
+  E extends SlackAppEnv = SlackAppEnv,
+  A extends BlockAction<BlockElementAction> = BlockAction<BlockElementAction>,
 > = (req: SlackRequestWithOptionalRespond<E, A>) => Promise<void>;
 
 /**

--- a/src_deno/app.ts
+++ b/src_deno/app.ts
@@ -20,6 +20,8 @@ import {
   SlackHandler,
   SlashCommandAckHandler,
   SlashCommandLazyHandler,
+  SourceSpecifiedBlockActionAckHandler,
+  SourceSpecifiedBlockActionLazyHandler,
   ViewAckHandler,
   ViewClosedAckHandler,
   ViewClosedLazyHandler,
@@ -683,8 +685,12 @@ export class SlackApp<E extends SlackEdgeAppEnv | SlackSocketModeAppEnv> {
       block_id?: string;
       action_id: string;
     },
-    ack: BlockActionAckHandler<T, E, A>,
-    lazy: BlockActionLazyHandler<T, E, A> = noopLazyHandler,
+    ack:
+      | BlockActionAckHandler<T, E, A>
+      | SourceSpecifiedBlockActionAckHandler<E, A>,
+    lazy:
+      | BlockActionLazyHandler<T, E, A>
+      | SourceSpecifiedBlockActionLazyHandler<E, A> = noopLazyHandler,
   ): SlackApp<E> {
     const handler: SlackHandler<E, A> = { ack, lazy };
     this.#blockActions.push((body) => {

--- a/src_deno/handler/handler.ts
+++ b/src_deno/handler/handler.ts
@@ -3,6 +3,7 @@ import { EventRequest, MessageEventHandler } from "../app.ts";
 import { SlackAppEnv } from "../app-env.ts";
 import {
   BlockAction,
+  BlockElementAction,
   BlockElementActions,
   BlockElementTypes,
 } from "../request/payload/block-action.ts";
@@ -172,6 +173,14 @@ export type BlockActionAckHandler<
 > = (req: SlackRequestWithOptionalRespond<E, A>) => Promise<AckResponse>;
 
 /**
+ * ack function for block_actions request handling.
+ */
+export type SourceSpecifiedBlockActionAckHandler<
+  E extends SlackAppEnv = SlackAppEnv,
+  A extends BlockAction<BlockElementAction> = BlockAction<BlockElementAction>,
+> = (req: SlackRequestWithOptionalRespond<E, A>) => Promise<AckResponse>;
+
+/**
  * lazy function for block_actions request handling.
  */
 export type BlockActionLazyHandler<
@@ -179,6 +188,11 @@ export type BlockActionLazyHandler<
   E extends SlackAppEnv = SlackAppEnv,
   A extends BlockAction<Extract<BlockElementActions, { type: T }>> =
     BlockAction<Extract<BlockElementActions, { type: T }>>,
+> = (req: SlackRequestWithOptionalRespond<E, A>) => Promise<void>;
+
+export type SourceSpecifiedBlockActionLazyHandler<
+  E extends SlackAppEnv = SlackAppEnv,
+  A extends BlockAction<BlockElementAction> = BlockAction<BlockElementAction>,
 > = (req: SlackRequestWithOptionalRespond<E, A>) => Promise<void>;
 
 /**

--- a/src_deno/request/payload/block-action.ts
+++ b/src_deno/request/payload/block-action.ts
@@ -9,12 +9,117 @@ import {
 import { DataSubmissionView, ViewStateValue } from "./view-objects.ts";
 import { BotProfile } from "./event.ts";
 
-/**
- * block_actions payload data
- */
-export interface BlockAction<A extends BlockElementAction> {
+// ------------------------------------------
+// The whole block_actions payload
+// ------------------------------------------
+
+export type BlockAction<A extends BlockElementAction> =
+  | MessageBlockAction<A>
+  | ViewBlockAction<A>
+  | FunctionBlockAction<A>;
+
+// To narrow the type down to this, you can have either `if ("message" in payload) { ... }` or SourceSpecifiedBlockActionAckHandler
+export type MessageBlockAction<A extends BlockElementAction> =
+  & BaseBlockAction<A>
+  & {
+    channel: {
+      id: string;
+      name: string;
+    };
+    message: {
+      type: "message";
+      user?: string;
+      ts: string;
+      thread_ts?: string;
+      text: string;
+      metadata?: MessageMetadata;
+      blocks?: AnyMessageBlock[];
+      attachments?: MessageAttachment[];
+      bot_id?: string;
+      bot_profile?: BotProfile;
+      edited?: {
+        user: string;
+        ts: string;
+      };
+      // deno-lint-ignore no-explicit-any
+      [key: string]: any;
+    };
+    response_url: string;
+    container: // blocks in a message
+      | {
+        type: "message";
+        message_ts: string;
+        channel_id: string;
+        is_ephemeral: boolean;
+      }
+      // blocks within an attachment
+      | {
+        type: "message_attachment";
+        message_ts: string;
+        attachment_id: number;
+        channel_id: string;
+        is_ephemeral: boolean;
+        is_app_unfurl: boolean;
+        app_unfurl_url?: string;
+        thread_ts?: string;
+      };
+    app_unfurl?: {
+      id: string;
+      app_id: string;
+      bot_id: string;
+      fallback: string;
+      app_unfurl_url: string;
+      is_app_unfurl: boolean;
+    };
+  };
+
+// To narrow the type down to this, you can have either `if ("view" in payload) { ... }` or SourceSpecifiedBlockActionAckHandler
+export type ViewBlockAction<A extends BlockElementAction> =
+  & BaseBlockAction<A>
+  & {
+    view: DataSubmissionView;
+    state: {
+      values: {
+        [blockId: string]: {
+          [actionId: string]: ViewStateValue;
+        };
+      };
+    };
+    container: {
+      type: "view";
+      view_id: string;
+    };
+  };
+
+// To narrow the type down to this, you can have either `if ("function_data" in payload) { ... }` or SourceSpecifiedBlockActionAckHandler
+export type FunctionBlockAction<A extends BlockElementAction> =
+  & BaseBlockAction<A>
+  & {
+    bot_access_token: string;
+    function_data: {
+      execution_id: string;
+      function: { callback_id: string };
+      inputs: {
+        // deno-lint-ignore no-explicit-any
+        [key: string]: any;
+      };
+    };
+    interactivity: {
+      interactivity_pointer: string;
+      interactor: { id: string; secret: string };
+    };
+  };
+
+export interface BaseBlockAction<A extends BlockElementAction> {
   type: "block_actions";
   actions: A[];
+  trigger_id: string;
+  api_app_id: string;
+  is_enterprise_install?: boolean;
+  enterprise?: {
+    id: string;
+    name: string;
+  };
   team: {
     id: string;
     domain: string;
@@ -26,80 +131,12 @@ export interface BlockAction<A extends BlockElementAction> {
     name: string;
     team_id?: string;
   };
-  channel?: {
-    id: string;
-    name: string;
-  };
-  message?: {
-    type: "message";
-    user?: string;
-    ts: string;
-    thread_ts?: string;
-    text?: string;
-    metadata?: MessageMetadata;
-    blocks?: AnyMessageBlock[];
-    attachments?: MessageAttachment[];
-    bot_id?: string;
-    bot_profile?: BotProfile;
-    edited?: {
-      user: string;
-      ts: string;
-    };
-    // deno-lint-ignore no-explicit-any
-    [key: string]: any;
-  };
-  view?: DataSubmissionView;
-  state?: {
-    values: {
-      [blockId: string]: {
-        [actionId: string]: ViewStateValue;
-      };
-    };
-  };
-  token: string;
-  response_url: string;
-  trigger_id: string;
-  api_app_id: string;
-  container: {
-    type: string;
-    message_ts?: string;
-    attachment_id?: number;
-    channel_id?: string;
-    view_id?: string;
-    text?: string;
-    is_ephemeral?: boolean;
-    is_app_unfurl?: boolean;
-    app_unfurl_url?: string;
-    thread_ts?: string;
-  };
-  app_unfurl?: {
-    id: string;
-    fallback: string;
-    bot_id: string;
-    app_unfurl_url: string;
-    is_app_unfurl: boolean;
-    app_id: string;
-  };
-  is_enterprise_install?: boolean;
-  enterprise?: {
-    id: string;
-    name: string;
-  };
-  // remote functions
-  bot_access_token?: string;
-  function_data?: {
-    execution_id: string;
-    function: { callback_id: string };
-    inputs: {
-      // deno-lint-ignore no-explicit-any
-      [key: string]: any;
-    };
-  };
-  interactivity?: {
-    interactivity_pointer: string;
-    interactor: { id: string; secret: string };
-  };
+  token: string; // legacy verification token
 }
+
+// ------------------------------------------
+// Block element actions
+// ------------------------------------------
 
 export interface BlockElementAction<T extends string = string> {
   type: T;

--- a/test/node-socket-mode/package.json
+++ b/test/node-socket-mode/package.json
@@ -4,7 +4,7 @@
   "description": "Simple project template for Slack app",
   "main": "lib/main.js",
   "scripts": {
-    "start": "npm run build && node lib/main.js",
+    "start": "nodemon --watch 'src/**/*.ts' --exec \"ts-node\" src/main.ts",
     "format": "npx prettier -w src/ && npx prettier -w *.json",
     "build": "tsc -p .",
     "local": "npm run build:live",


### PR DESCRIPTION
This pull request improves the `app.action` handler's `payload` data types in TS. The major changes are:
- More accuracy on some properties (e.g., container and state)
- Enable developers to dispatch message/view patterns

In your code, having if/else statements can safely narrow down the type from the union. This is much safer than `payload.message!.ts` pattern for both TS compilation and runtime behavior.

```typescript
const button: BlockActionAckHandler<"button", MyEnv> = async ({ payload, env }) => {
  // common properties such as actions[], team, user, etc. are available without if/else
  const type: "block_actions" = payload.type;
  const action: ButtonAction = payload.actions[0];

  if ("message" in payload) {
    // an action on a channel message
    // payload.message, payload.channel, and payload.response_url are only available for this pattern
    const messageTs: string = payload.message.ts;
    const channelId: string = payload.channel.id;
    // for a workflow custom step, this has to be optional
    const responseUrl: string | undefined = payload.response_url;

  } else if ("view" in payload) {
    // an action on a modal view/home tab
    // payload.view is only available for this pattern
    const view: DataSubmissionView = payload.view;
   // message and channel never exist in this clause
  }

  // the properties from a custom workflow step are all optional
  // It's possible to have more strict typing here, but it harms the users who are not interested in custom steps
  // Therefore, I decided to go with only message or view
  const functionId: string | undefined = payload.function_data?.execution_id;
  const interactivityPointer: string | undefined = payload.interactivity?.interactivity_pointer;
};

app.action<"button">("action_id", async ({ payload }) => {
  const type: "block_actions" = payload.type;
  const action: ButtonAction = payload.actions[0];
  if ("message" in payload) {
    const messageTs: string = payload.message.ts;
    const channelId: string = payload.channel.id;
    // for a workflow custom step, this has to be optional
    const responseUrl: string | undefined = payload.response_url;
  }
});
```

Also, if an app can safely assume an action comes only from a message (or modal view), newly added SourceSpecifiedBlockActionAck/LazyHandler are useful to eliminate the above if/else blocks.

```typescript
const button: SourceSpecifiedBlockActionAckHandler<MyEnv, MessageBlockAction<ButtonAction>> = async ({ payload, env }) => {
  const type: "block_actions" = payload.type;
  const action: ButtonAction = payload.actions[0];
  // This can result in a runtime error if the handler receives other patterns
  const messageTs: string = payload.message.ts;
  const channelId: string = payload.channel.id;
  // for a workflow custom step, this has to be optional
  const responseUrl: string | undefined = payload.response_url;
};

app.action<"button", MessageBlockAction<ButtonAction>>("action_id", async ({ payload }) => {
  const type: "block_actions" = payload.type;
  const action: ButtonAction = payload.actions[0];
  // This can result in a runtime error if the handler receives other patterns
  const messageTs: string = payload.message.ts;
  const channelId: string = payload.channel.id;
  // for a workflow custom step, this has to be optional
  const responseUrl: string | undefined = payload.response_url;
});
```

I don't think this could be a breaking change to any existing apps. Even if an app can be affected, this improvement should benefit them in the long run. I am thinking of releasing a new minor version with this change.