### PR TITLE
Update example code for Vercel Edge

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,7 +92,8 @@ npm i slack-edge
 Create a new source file `pages/api/slack.ts` that contains the following code:
 
 ```typescript
-import type { NextFetchEvent, NextRequest } from "next/server";
+import type { NextRequest } from "next/server";
+import { waitUntil } from '@vercel/functions';
 import { SlackApp } from "slack-edge";
 
 export const config = {
@@ -121,11 +122,10 @@ app.command("/hello-edge",
   }
 );
 
-export default async function handler(
-  req: NextRequest,
-  context: NextFetchEvent
+export async function POST(
+  req: NextRequest
 ) {
-  return await app.run(req, context);
+  return await app.run(req, {waitUntil});
 }
 ```
 

--- a/README.md
+++ b/README.md
@@ -125,7 +125,7 @@ app.command("/hello-edge",
 export async function POST(
   req: NextRequest
 ) {
-  return await app.run(req, {waitUntil});
+  return await app.run(req, { waitUntil });
 }
 ```
 


### PR DESCRIPTION
### 1. Fix `TypeError: ctx.waitUntil is not a function`

The `waitUntil` is provided by the package '@vercel/functions'.

See: 
* https://vercel.com/changelog/waituntil-is-now-available-for-vercel-functions
* https://vercel.com/docs/functions/functions-api-reference#waituntil

### 2. Export the POST function instead of default handler

Fix the error in Next.js app router.

`⨯ Detected default export in '/project/app/api/slack/route.ts'. Export a named export for each HTTP method instead.`

And according to Slack, it will only send POST requests to this endpoint.

![CleanShot 2024-10-22 at 13 25 17@2x](https://github.com/user-attachments/assets/051b50a1-c9f1-40fa-b498-51eec858e693)
