### PR TITLE
Correct Next.js app route path in README.md file

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,7 +89,7 @@ cd your-app-name
 npm i slack-edge
 ```
 
-Create a new source file `pages/api/slack.ts` that contains the following code:
+Create a new source file `app/api/slack.ts` that contains the following code:
 
 ```typescript
 import type { NextRequest } from "next/server";


### PR DESCRIPTION
the Next.js uses the app router system by default and the file we provided should be under the directory `app` instead of  `pages`