### PR TITLE
Fix #40 invalid event name

### DIFF
--- a/src/app.ts
+++ b/src/app.ts
@@ -209,7 +209,7 @@ export class SlackApp<E extends SlackEdgeAppEnv | SlackSocketModeAppEnv> {
   // --------------------------
 
   #slashCommands: ((body: SlackRequestBody) => SlackMessageHandler<E, SlashCommand> | null)[] = [];
-  #events: ((body: SlackRequestBody) => SlackHandler<E, SlackEvent<string>> | null)[] = [];
+  #events: ((body: SlackRequestBody) => SlackHandler<E, SlackEvent<AnyEventType>> | null)[] = [];
   #globalShorcuts: ((body: SlackRequestBody) => SlackHandler<E, GlobalShortcut> | null)[] = [];
   #messageShorcuts: ((body: SlackRequestBody) => SlackHandler<E, MessageShortcut> | null)[] = [];
   #blockActions: ((body: SlackRequestBody) => SlackHandler<
@@ -927,7 +927,7 @@ export class SlackApp<E extends SlackEdgeAppEnv | SlackSocketModeAppEnv> {
 
       if (body.type === PayloadType.EventsAPI) {
         // Events API
-        const slackRequest: SlackRequest<E, SlackEvent<string>> = {
+        const slackRequest: SlackRequest<E, SlackEvent<AnyEventType>> = {
           payload: body.event,
           ...baseRequest,
         };

--- a/src/request/payload/event.ts
+++ b/src/request/payload/event.ts
@@ -1,4 +1,4 @@
-import { AnyMessageBlock, HomeTabView, MessageAttachment, MessageMetadata } from "slack-web-api-client";
+import { AnyManifestEvent, AnyMessageBlock, HomeTabView, MessageAttachment, MessageMetadata } from "slack-web-api-client";
 
 export type AnySlackEvent =
   | AppRequestedEvent
@@ -70,7 +70,7 @@ export type AnySlackEvent =
   | SubteamUpdatedEvent
   | TeamAccessGrantedEvent
   | TeamAccessRevokedEvent
-  | TeamDomainChangedEvent
+  | TeamDomainChangeEvent
   | TeamJoinEvent
   | TeamRenameEvent
   | TokensRevokedEvent
@@ -139,7 +139,7 @@ export type AnySlackAssistantThreadEvent =
 /**
  * Events API payload data
  */
-export interface SlackEvent<Type extends string> {
+export interface SlackEvent<Type extends AnyManifestEvent> {
   type: Type;
   subtype?: string;
 }
@@ -874,8 +874,8 @@ export interface TeamAccessRevokedEvent extends SlackEvent<"team_access_revoked"
   event_ts: string;
 }
 
-export interface TeamDomainChangedEvent extends SlackEvent<"team_domain_changed"> {
-  type: "team_domain_changed";
+export interface TeamDomainChangeEvent extends SlackEvent<"team_domain_change"> {
+  type: "team_domain_change";
   url: string;
   domain: string;
 }

--- a/src_deno/app.ts
+++ b/src_deno/app.ts
@@ -248,9 +248,9 @@ export class SlackApp<E extends SlackEdgeAppEnv | SlackSocketModeAppEnv> {
   #slashCommands: ((
     body: SlackRequestBody,
   ) => SlackMessageHandler<E, SlashCommand> | null)[] = [];
-  #events:
-    ((body: SlackRequestBody) => SlackHandler<E, SlackEvent<string>> | null)[] =
-      [];
+  #events: ((
+    body: SlackRequestBody,
+  ) => SlackHandler<E, SlackEvent<AnyEventType>> | null)[] = [];
   #globalShorcuts:
     ((body: SlackRequestBody) => SlackHandler<E, GlobalShortcut> | null)[] = [];
   #messageShorcuts:
@@ -1113,7 +1113,7 @@ export class SlackApp<E extends SlackEdgeAppEnv | SlackSocketModeAppEnv> {
 
       if (body.type === PayloadType.EventsAPI) {
         // Events API
-        const slackRequest: SlackRequest<E, SlackEvent<string>> = {
+        const slackRequest: SlackRequest<E, SlackEvent<AnyEventType>> = {
           payload: body.event,
           ...baseRequest,
         };

--- a/src_deno/request/payload/event.ts
+++ b/src_deno/request/payload/event.ts
@@ -1,4 +1,5 @@
 import {
+  AnyManifestEvent,
   AnyMessageBlock,
   HomeTabView,
   MessageAttachment,
@@ -75,7 +76,7 @@ export type AnySlackEvent =
   | SubteamUpdatedEvent
   | TeamAccessGrantedEvent
   | TeamAccessRevokedEvent
-  | TeamDomainChangedEvent
+  | TeamDomainChangeEvent
   | TeamJoinEvent
   | TeamRenameEvent
   | TokensRevokedEvent
@@ -144,7 +145,7 @@ export type AnySlackAssistantThreadEvent =
 /**
  * Events API payload data
  */
-export interface SlackEvent<Type extends string> {
+export interface SlackEvent<Type extends AnyManifestEvent> {
   type: Type;
   subtype?: string;
 }
@@ -901,9 +902,9 @@ export interface TeamAccessRevokedEvent
   event_ts: string;
 }
 
-export interface TeamDomainChangedEvent
-  extends SlackEvent<"team_domain_changed"> {
-  type: "team_domain_changed";
+export interface TeamDomainChangeEvent
+  extends SlackEvent<"team_domain_change"> {
+  type: "team_domain_change";
   url: string;
   domain: string;
 }


### PR DESCRIPTION
This pull request resolves #40. To prevent this type of coding error from happening again, I adjusted the type constraint to allow only the ones listed in AnyEventType. Will ship the change as a new minor version release.