### PR TITLE
add types for channel_convert_to_private message event

### DIFF
--- a/src/request/payload/event.ts
+++ b/src/request/payload/event.ts
@@ -1344,7 +1344,8 @@ export type AnyMessageEvent =
   | GenericMessageEvent
   | BotMessageEvent
   | ChannelArchiveMessageEvent
-  | ChannelConvertToPublicessageEvent
+  | ChannelConvertToPrivateMessageEvent
+  | ChannelConvertToPublicMessageEvent
   | ChannelJoinMessageEvent
   | ChannelLeaveMessageEvent
   | ChannelNameMessageEvent
@@ -1505,7 +1506,18 @@ export interface ChannelPostingPermissionsMessageEvent extends SlackEvent<"messa
   event_ts: string;
 }
 
-export interface ChannelConvertToPublicessageEvent extends SlackEvent<"message"> {
+export interface ChannelConvertToPrivateMessageEvent extends SlackEvent<"message"> {
+  type: "message";
+  subtype: "channel_convert_to_private";
+  ts: string;
+  text: string;
+  user: string;
+  channel: string;
+  event_ts: string;
+  channel_type: string;
+}
+
+export interface ChannelConvertToPublicMessageEvent extends SlackEvent<"message"> {
   type: "message";
   subtype: "channel_convert_to_public";
   ts: string;

--- a/src_deno/request/payload/event.ts
+++ b/src_deno/request/payload/event.ts
@@ -1380,7 +1380,8 @@ export type AnyMessageEvent =
   | GenericMessageEvent
   | BotMessageEvent
   | ChannelArchiveMessageEvent
-  | ChannelConvertToPublicessageEvent
+  | ChannelConvertToPrivateMessageEvent
+  | ChannelConvertToPublicMessageEvent
   | ChannelJoinMessageEvent
   | ChannelLeaveMessageEvent
   | ChannelNameMessageEvent
@@ -1545,7 +1546,18 @@ export interface ChannelPostingPermissionsMessageEvent
   event_ts: string;
 }
 
-export interface ChannelConvertToPublicessageEvent
+export interface ChannelConvertToPrivateMessageEvent extends SlackEvent<"message"> {
+  type: "message";
+  subtype: "channel_convert_to_private";
+  ts: string;
+  text: string;
+  user: string;
+  channel: string;
+  event_ts: string;
+  channel_type: string;
+}
+
+export interface ChannelConvertToPublicMessageEvent
   extends SlackEvent<"message"> {
   type: "message";
   subtype: "channel_convert_to_public";


### PR DESCRIPTION
1. Fix typo on `ChannelConvertToPublicessageEvent` type
2. Add type support for unlisted `channel_convert_to_private` message event, based on this conversation: https://community.slack.com/archives/C02C28Z3XA7/p1730963855327819