### PR TITLE
Add authorizeErrorHandler hook to deal with edge cases

### DIFF
--- a/src/authorization/authorize-error-handler.ts
+++ b/src/authorization/authorize-error-handler.ts
@@ -1,0 +1,22 @@
+import { SlackAppEnv } from "../app-env";
+import { AuthorizeError } from "../errors";
+import { PreAuthorizeSlackMiddlewareRequest } from "../request/request";
+
+export interface AuthorizeErrorHandlerArgs<E extends SlackAppEnv> {
+  request: PreAuthorizeSlackMiddlewareRequest<E>;
+  error: AuthorizeError;
+}
+
+/**
+ * The function that handles an error thrown by authorize function. If this function returns a Response instead of the thrown exception, the App immediately returns the response and skip executing all the following middleware and listeners.
+ */
+export type AuthorizeErrorHandler<E extends SlackAppEnv = SlackAppEnv> = (
+  args: AuthorizeErrorHandlerArgs<E>,
+) => Promise<Response | AuthorizeError>;
+
+export function buildDefaultAuthorizeErrorHanlder<E extends SlackAppEnv>(): AuthorizeErrorHandler<E> {
+  // deno-lint-ignore require-await
+  return async ({ error }) => {
+    return error;
+  };
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -17,6 +17,7 @@ export * from "./handler/options-handler";
 export * from "./handler/view-handler";
 
 export * from "./authorization/authorize";
+export * from "./authorization/authorize-error-handler";
 export * from "./authorization/authorize-result";
 export * from "./authorization/single-team-authorize";
 

--- a/src_deno/authorization/authorize-error-handler.ts
+++ b/src_deno/authorization/authorize-error-handler.ts
@@ -1,0 +1,24 @@
+import { SlackAppEnv } from "../app-env.ts";
+import { AuthorizeError } from "../errors.ts";
+import { PreAuthorizeSlackMiddlewareRequest } from "../request/request.ts";
+
+export interface AuthorizeErrorHandlerArgs<E extends SlackAppEnv> {
+  request: PreAuthorizeSlackMiddlewareRequest<E>;
+  error: AuthorizeError;
+}
+
+/**
+ * The function that handles an error thrown by authorize function. If this function returns a Response instead of the thrown exception, the App immediately returns the response and skip executing all the following middleware and listeners.
+ */
+export type AuthorizeErrorHandler<E extends SlackAppEnv = SlackAppEnv> = (
+  args: AuthorizeErrorHandlerArgs<E>,
+) => Promise<Response | AuthorizeError>;
+
+export function buildDefaultAuthorizeErrorHanlder<
+  E extends SlackAppEnv,
+>(): AuthorizeErrorHandler<E> {
+  // deno-lint-ignore require-await
+  return async ({ error }) => {
+    return error;
+  };
+}

--- a/src_deno/index.ts
+++ b/src_deno/index.ts
@@ -17,6 +17,7 @@ export * from "./handler/options-handler.ts";
 export * from "./handler/view-handler.ts";
 
 export * from "./authorization/authorize.ts";
+export * from "./authorization/authorize-error-handler.ts";
 export * from "./authorization/authorize-result.ts";
 export * from "./authorization/single-team-authorize.ts";
 

--- a/test/app.test.ts
+++ b/test/app.test.ts
@@ -40,6 +40,10 @@ describe("SlackApp", () => {
   test("initialization", () => {
     const app = new SlackApp({
       env: { SLACK_SIGNING_SECRET: "test", SLACK_BOT_TOKEN: "xoxb-" },
+      authorizeErrorHandler: async ({ request, error }) => {
+        // Just acknowledge the request this app cannot handle
+        return new Response("", { status: 200 });
+      },
     });
     assert.exists(app.client);
   });

--- a/test/node-socket-mode/src/app.ts
+++ b/test/node-socket-mode/src/app.ts
@@ -1,3 +1,4 @@
+import { AuthorizeError } from "slack-edge";
 import { SlackApp, SlackAPIError, AssistantThreadContext } from "../../../src/index"; // "slack-edge"
 
 type LogLevel = "DEBUG" | "INFO" | "WARN" | "ERROR";
@@ -11,6 +12,9 @@ export const app = new SlackApp({
     SLACK_APP_TOKEN: process.env.SLACK_APP_TOKEN!,
     SLACK_LOGGING_LEVEL: logLevel,
   },
+  // authorizeErrorHandler testing
+  // authorize: async () => { throw new AuthorizeError("test") },
+  // authorizeErrorHandler: async () => new Response("", { status: 200}),
 });
 
 app.assistantThreadStarted(async ({ context: { threadContext, say, setSuggestedPrompts, channelId, threadTs } }) => {


### PR DESCRIPTION
This pull request introduces a new hook called "authorizeErrorHandler", which enables developers to deal with edge cases like unexpected event deliveries for users in a different workspace. This does not change the default behavior at all. Developers can opt-in by implementing authorizeErrorHandler hook and passing it to SlackApp constructor.