### PR TITLE
Export response body

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -55,6 +55,7 @@ export * from "./request/payload/view-closed";
 export * from "./request/payload/view-objects";
 
 export * from "./response/response";
+export * from "./response/response-body";
 export * from "./socket-mode/socket-mode-client";
 export * from "./socket-mode/payload-handler";
 

--- a/src_deno/index.ts
+++ b/src_deno/index.ts
@@ -55,6 +55,7 @@ export * from "./request/payload/view-closed.ts";
 export * from "./request/payload/view-objects.ts";
 
 export * from "./response/response.ts";
+export * from "./response/response-body.ts";
 export * from "./socket-mode/socket-mode-client.ts";
 export * from "./socket-mode/payload-handler.ts";
 


### PR DESCRIPTION
This PR exports the response-body types. Currently, They are defined internally but not exported, which limits its usability for developers who need to handle Slack message responses in their own codebases. By exporting this type, developers can directly reference it, improving type safety and reducing the need to redefine the same structure in their projects.