### PR TITLE
Add `entity_details_requested` event type support

### DIFF
--- a/src/request/payload/event.ts
+++ b/src/request/payload/event.ts
@@ -58,6 +58,7 @@ export type AnySlackEvent =
   | DNDUpdatedUserEvent
   | EmailDomainChangedEvent
   | EmojiChangedEvent
+  | EntityDetailsRequestedEvent
   | FileChangeEvent
   | FileCreatedEvent
   | FileDeletedEvent
@@ -509,6 +510,27 @@ export interface EmojiChangedEvent extends SlackEvent<"emoji_changed"> {
   old_name?: string;
   new_name?: string;
   event_ts: string;
+}
+
+export interface EntityDetailsRequestedEvent extends SlackEvent<"entity_details_requested"> {
+  type: "entity_details_requested";
+  user: string;
+  trigger_id: string;
+  link: {
+    url: string;
+    domain: string;
+  };
+  entity_url: string;
+  app_unfurl_url?: string;
+  user_locale: string;
+  event_ts: string;
+  external_ref?: {
+    id: string;
+    type?: string;
+  };
+  message_ts?: string;
+  thread_ts?: string;
+  channel?: string;
 }
 
 export interface FileChangeEvent extends SlackEvent<"file_change"> {


### PR DESCRIPTION
## Summary
- Add `EntityDetailsRequestedEvent` interface for the [`entity_details_requested`](https://docs.slack.dev/reference/events/entity_details_requested/) event (work objects support)
- Add `EntityDetailsRequestedEvent` to the `AnySlackEvent` union type

## Note
The `entity_details_requested` event type string has been added to `AnyEventType` in the upstream `slack-web-api-client` library via https://github.com/slack-edge/slack-web-api-client/pull/28. Once that PR is merged and the dependency is updated, the type constraint will resolve correctly.

## Context
Slack added the `entity_details_requested` event for work objects. The official `node-slack-sdk` added this in https://github.com/slackapi/node-slack-sdk/pull/2412.