### PR TITLE
Add event_ts and cache_ts to TeamJoinEvent

### DIFF
--- a/src/request/payload/event.ts
+++ b/src/request/payload/event.ts
@@ -1033,6 +1033,8 @@ export interface TeamJoinEvent extends SlackEvent<"team_join"> {
     is_workflow_bot?: boolean;
     who_can_share_contact_card: string;
   };
+  cache_ts?: number;
+  event_ts: string;
 }
 
 export interface TeamRenameEvent extends SlackEvent<"team_rename"> {


### PR DESCRIPTION
## Summary
- Add `event_ts: string` and `cache_ts?: number` to the `TeamJoinEvent` interface, which were missing from the type definition despite being present on the actual `team_join` event payload.

Fixes #60

## Test plan
- [x] `npm run build` passes (tsc)