### PR TITLE
Embed sources in sourcemaps to fix missing-source warnings

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -7,6 +7,7 @@
     "declaration": true,
     "declarationMap": true,
     "sourceMap": true,
+    "inlineSources": true,
     "strict": true,
     "esModuleInterop": true,
     "allowJs": false


### PR DESCRIPTION
## Summary
- Enable `inlineSources` in `tsconfig.json` so `dist/*.js.map` files embed the TypeScript source into `sourcesContent` instead of only referencing `../src/*.ts` paths that aren't part of the published npm package.

## Why
The published package excludes `src/` (see `.npmignore`) but ships `dist/*.js.map` whose `sources` entries point at `../src/*.ts`. Tools that parse sourcemaps (e.g. workerd via `@cloudflare/vitest-pool-workers`) emit warnings like:

```
Sourcemap for ".../node_modules/slack-edge/dist/index.js" points to missing source files
```

With `inlineSources: true`, `tsc` embeds the original TS into the map's `sourcesContent` array, so consumers no longer try to fetch the missing files while preserving full debugger support.

Verified locally: after `npm run build:clean`, `dist/index.js.map` now contains a populated `sourcesContent` array matching the `sources` entries.

Fixes #69

## Test plan
- [ ] `npm run build:clean`
- [ ] Confirm each generated `dist/*.js.map` has a non-empty `sourcesContent` array

🤖 Generated with [Claude Code](https://claude.com/claude-code)