### PR TITLE
Add publish safeguards: prepublishOnly and files allowlist

### DIFF
--- a/RELEASING.md
+++ b/RELEASING.md
@@ -1,0 +1,47 @@
+# Releasing
+
+Publishing `slack-edge` to npm is manual. Follow these steps from a clean checkout of `main`.
+
+## Prerequisites
+
+- Push access to `slack-edge/slack-edge`.
+- An npm account with publish rights to the `slack-edge` package (`npm whoami` to check; `npm login` if not).
+
+## Steps
+
+1. **Sync `main`.**
+   ```sh
+   git checkout main && git pull
+   ```
+
+2. **Bump the version** in `package.json` following semver. Commit on `main` using the existing convention:
+   ```sh
+   git commit -am "version X.Y.Z"
+   git push
+   ```
+
+3. **Verify the build and tests pass.**
+   ```sh
+   npm ci
+   npm run build:clean
+   npm run ci-test
+   ```
+
+4. **Inspect the tarball** before shipping it.
+   ```sh
+   npm pack --dry-run
+   ```
+   Confirm the top-level entries are `dist/`, `LICENSE.txt`, `README.md`, and `package.json` — nothing else.
+
+5. **Publish to npm.** The `prepublishOnly` script runs `build:clean` automatically, so the tarball is always built fresh from source.
+   ```sh
+   npm publish
+   ```
+
+6. **Tag the release** and push the tag. Match the latest tag style (`vX.Y.Z`):
+   ```sh
+   git tag vX.Y.Z
+   git push --tags
+   ```
+
+7. **Create a GitHub release** against the new tag with a short changelog.

--- a/package.json
+++ b/package.json
@@ -3,12 +3,16 @@
   "version": "1.3.16",
   "description": "Slack app development framework for edge functions with streamlined TypeScript support",
   "main": "dist/index.js",
+  "files": [
+    "dist"
+  ],
   "scripts": {
     "build": "tsc",
     "build:clean": "rm -rf ./dist && tsc",
     "format": "npx @biomejs/biome format --write *.json src/ test/",
     "test": "npm run format && npx vitest",
-    "ci-test": "npx vitest run --coverage"
+    "ci-test": "npx vitest run --coverage",
+    "prepublishOnly": "npm run build:clean"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
## Summary
- Add `prepublishOnly` script that runs `build:clean`, so `npm publish` always ships a freshly compiled `dist/` instead of whatever happened to be on disk.
- Add a `files` allowlist (`["dist"]`) so the published tarball is explicit about what ships, rather than relying solely on `.npmignore`.

## Test plan
- [x] `npm run build:clean` succeeds.
- [x] `npm pack --dry-run` tarball top-level entries are exactly `dist/`, `LICENSE.txt`, `README.md`, `package.json` (215 files, 148 kB) — no `src/`, `src_deno/`, `test/`, `scripts/`, configs, or lockfiles leak in.
- [ ] Next release: confirm `npm publish` triggers the rebuild via `prepublishOnly`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)