### PR TITLE
version 1.3.17

### DIFF
--- a/RELEASING.md
+++ b/RELEASING.md
@@ -1,6 +1,6 @@
 # Releasing
 
-Publishing `slack-edge` to npm is manual. Follow these steps from a clean checkout of `main`.
+Publishing `slack-edge` to npm is manual. The version bump goes through a pull request; the publish itself happens locally from `main` after the PR merges.
 
 ## Prerequisites
 
@@ -9,15 +9,15 @@ Publishing `slack-edge` to npm is manual. Follow these steps from a clean checko
 
 ## Steps
 
-1. **Sync `main`.**
+1. **Sync `main` and create a release branch.**
    ```sh
    git checkout main && git pull
+   git checkout -b version-X.Y.Z
    ```
 
-2. **Bump the version** in `package.json` following semver. Commit on `main` using the existing convention:
+2. **Bump the version** in `package.json` following semver, then refresh `package-lock.json` so both files stay in sync:
    ```sh
-   git commit -am "version X.Y.Z"
-   git push
+   npm install --package-lock-only
    ```
 
 3. **Verify the build and tests pass.**
@@ -27,21 +27,34 @@ Publishing `slack-edge` to npm is manual. Follow these steps from a clean checko
    npm run ci-test
    ```
 
-4. **Inspect the tarball** before shipping it.
+4. **Commit, push, and open a PR** against `main` using the existing convention:
+   ```sh
+   git commit -am "version X.Y.Z"
+   git push -u origin version-X.Y.Z
+   gh pr create --base main --title "version X.Y.Z"
+   ```
+   Get the PR reviewed and merged before continuing.
+
+5. **Return to `main` and pull the merged commit.**
+   ```sh
+   git checkout main && git pull
+   ```
+
+6. **Inspect the tarball** before shipping it.
    ```sh
    npm pack --dry-run
    ```
    Confirm the top-level entries are `dist/`, `LICENSE.txt`, `README.md`, and `package.json` — nothing else.
 
-5. **Publish to npm.** The `prepublishOnly` script runs `build:clean` automatically, so the tarball is always built fresh from source.
+7. **Publish to npm.** The `prepublishOnly` script runs `build:clean` automatically, so the tarball is always built fresh from source.
    ```sh
    npm publish
    ```
 
-6. **Tag the release** and push the tag. Match the latest tag style (`vX.Y.Z`):
+8. **Tag the release** and push the tag. Match the latest tag style (`vX.Y.Z`):
    ```sh
    git tag vX.Y.Z
    git push --tags
    ```
 
-7. **Create a GitHub release** against the new tag with a short changelog.
+9. **Create a GitHub release** against the new tag with a short changelog.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "slack-edge",
-  "version": "1.3.16",
+  "version": "1.3.17",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "slack-edge",
-      "version": "1.3.16",
+      "version": "1.3.17",
       "license": "MIT",
       "dependencies": {
         "slack-web-api-client": "^1.1.12"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "slack-edge",
-  "version": "1.3.16",
+  "version": "1.3.17",
   "description": "Slack app development framework for edge functions with streamlined TypeScript support",
   "main": "dist/index.js",
   "files": [


### PR DESCRIPTION
## Summary
- Patch bump to `1.3.17` covering changes merged since `1.3.16`:
  - `Add event_ts and cache_ts to TeamJoinEvent` (#70)
  - `Embed sources in sourcemaps via inlineSources`
  - `Update npm dependencies` (#72) — incl. `slack-web-api-client` → `1.1.12`
  - `Add publish safeguards: prepublishOnly and files allowlist` (#73)
  - `Add RELEASING.md with npm publish steps`
  - `Add .context/ to gitignore and npmignore`

## Test plan
- [x] `npm ci`
- [x] `npm run build:clean`
- [x] `npm run ci-test` (24/24 passing)
- [ ] After merge: tag `v1.3.17`, `npm publish`, push tag, create GitHub release per `RELEASING.md`