### PR TITLE
Add Dependabot config for npm and GitHub Actions

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,23 @@
+version: 2
+updates:
+  - package-ecosystem: npm
+    directory: /
+    schedule:
+      interval: weekly
+    open-pull-requests-limit: 10
+    groups:
+      dev-dependencies:
+        dependency-type: development
+        update-types:
+          - minor
+          - patch
+      production-dependencies:
+        dependency-type: production
+        update-types:
+          - minor
+          - patch
+
+  - package-ecosystem: github-actions
+    directory: /
+    schedule:
+      interval: weekly


### PR DESCRIPTION
## Summary
- Adds `.github/dependabot.yml` with weekly update checks
- npm minor/patch updates grouped into dev and prod PRs to reduce noise; majors come through individually
- Also tracks GitHub Actions versions

## Test plan
- [ ] Verify Dependabot picks up the config on the Insights tab after merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)