### PR TITLE
Add streaming helpers, global error handler, and harden signature verification

### DIFF
--- a/README.md
+++ b/README.md
@@ -379,6 +379,24 @@ app.error(async ({ error, request, body }) => {
 
 You can also pass it at construction time via the `errorHandler` option. When no handler is registered, slack-edge logs the error and returns a safe response (`500` for the ack phase), preserving the previous behavior.
 
+#### Streaming AI Messages
+
+For AI assistants, `context.sayStream` is a `say`-style helper that streams a message token-by-token. Like `say`, it auto-sources `channel_id`/`thread_ts` from the request (and, in an assistant thread, attaches the thread context metadata). It returns a handle with `.append()` and `.stop()`:
+
+```ts
+app.event("app_mention", async ({ context }) => {
+  const stream = await context.sayStream({ loading_messages: ["Thinking…"] });
+  for await (const chunk of someLLM()) {
+    await stream.append(chunk); // markdown string, or { markdown_text }
+  }
+  await stream.stop(); // optionally pass final markdown / blocks / metadata
+});
+```
+
+It works in both `app.assistant(...)` utilities and plain `app.event` / `app.message` listeners. Note that the underlying `chat.startStream` API requires a thread, so pass `thread_ts` for non-threaded channel events.
+
+The lower-level `startMessageStream(client, params)` wraps the raw `chat.startStream` → `chat.appendStream*` → `chat.stopStream` lifecycle directly if you need it without a listener context.
+
 #### `ack` / `lazy` Functions
 
 You may be unfamiliar with the "lazy listener" concept in this framework. To learn more about it, please read bolt-python's documentation: https://tools.slack.dev/bolt-python/concepts/lazy-listeners

--- a/README.md
+++ b/README.md
@@ -365,6 +365,20 @@ This framework offers ways to globally customize your app's behavior, like you d
 |app.beforeAuthorize|The passed function does something before calling `authorize()` function. If this method returns `SlackResponse`, the following middleware and listeners won't be executed.|
 |app.afterAuthorize / app.use / app.middleware|The passed function does something right after calling `authorize()` function. If this method returns `SlackResponse`, the following middleware and listeners won't be executed.|
 
+#### Global Error Handler
+
+Register a single catch-all handler for any error thrown by a post-authorize middleware or a listener (both `ack` and `lazy`). This mirrors bolt-js's `app.error()` and is separate from `authorizeErrorHandler`, which only handles `authorize()` failures.
+
+```ts
+app.error(async ({ error, request, body }) => {
+  console.error(`Something went wrong: ${error.stack}`);
+  // For ack-phase errors you may return a Response to control what Slack receives.
+  // (Errors thrown inside lazy listeners are already acknowledged, so a returned Response is ignored.)
+});
+```
+
+You can also pass it at construction time via the `errorHandler` option. When no handler is registered, slack-edge logs the error and returns a safe response (`500` for the ack phase), preserving the previous behavior.
+
 #### `ack` / `lazy` Functions
 
 You may be unfamiliar with the "lazy listener" concept in this framework. To learn more about it, please read bolt-python's documentation: https://tools.slack.dev/bolt-python/concepts/lazy-listeners

--- a/src/app.ts
+++ b/src/app.ts
@@ -258,7 +258,7 @@ export class SlackApp<E extends SlackEdgeAppEnv | SlackSocketModeAppEnv> {
       // because the underlying WS connection are securely established.
       this.signingSecret = "";
     } else {
-      if (!this.env.SLACK_SIGNING_SECRET) {
+      if (!this.env.SLACK_SIGNING_SECRET || this.env.SLACK_SIGNING_SECRET.trim() === "") {
         throw new ConfigError("env.SLACK_SIGNING_SECRET is required to run your app on edge functions!");
       }
       this.signingSecret = this.env.SLACK_SIGNING_SECRET;

--- a/src/app.ts
+++ b/src/app.ts
@@ -13,6 +13,7 @@ import { Authorize } from "./authorization/authorize";
 import { AuthorizeErrorHandler, buildDefaultAuthorizeErrorHanlder } from "./authorization/authorize-error-handler";
 import { AuthorizeResult } from "./authorization/authorize-result";
 import { singleTeamAuthorize } from "./authorization/single-team-authorize";
+import { SlackAppErrorHandler } from "./error-handler";
 import {
   builtBaseContext,
   isAssitantThreadEvent,
@@ -92,6 +93,12 @@ export interface SlackAppOptions<E extends SlackEdgeAppEnv | SlackSocketModeAppE
   authorizeErrorHandler?: AuthorizeErrorHandler<E>;
 
   /**
+   * The global error handler invoked when a post-authorize middleware or a listener throws.
+   * Can also be registered later via `app.error()`.
+   */
+  errorHandler?: SlackAppErrorHandler<E>;
+
+  /**
    * The endpoint routes to handle requests from Slack's API server.
    * When this app connects to Slack through Socket Mode, this setting won't be used.
    */
@@ -153,6 +160,12 @@ export class SlackApp<E extends SlackEdgeAppEnv | SlackSocketModeAppEnv> {
    * The hoook that handles authorization failure.
    */
   public authorizeErrorHandler: AuthorizeErrorHandler<E>;
+
+  /**
+   * The global error handler invoked when a post-authorize middleware or a listener throws.
+   * When undefined, errors are logged and a safe response is returned.
+   */
+  public errorHandler: SlackAppErrorHandler<E> | undefined;
 
   /**
    * The endpoint routes to handle requests from Slack's API server.
@@ -271,6 +284,7 @@ export class SlackApp<E extends SlackEdgeAppEnv | SlackSocketModeAppEnv> {
     }
     this.authorize = options.authorize ?? singleTeamAuthorize;
     this.authorizeErrorHandler = options.authorizeErrorHandler ?? buildDefaultAuthorizeErrorHanlder();
+    this.errorHandler = options.errorHandler;
     this.routes = { events: options.routes?.events };
     this.assistantThreadContextStore = options.assistantThreadContextStore;
     this.#assistantEnabled = options.assistantThreadContextStore !== undefined;
@@ -312,6 +326,56 @@ export class SlackApp<E extends SlackEdgeAppEnv | SlackSocketModeAppEnv> {
   afterAuthorize(middleware: Middleware<E>): SlackApp<E> {
     this.postAuthorizeMiddleware.push(middleware);
     return this;
+  }
+
+  /**
+   * Registers the global error handler invoked when a post-authorize middleware or a listener
+   * throws. Only a single handler is supported; calling this again replaces the previous one.
+   * This naming is for consistency with bolt-js.
+   * @param handler the global error handler
+   * @returns this instance
+   */
+  error(handler: SlackAppErrorHandler<E>): SlackApp<E> {
+    this.errorHandler = handler;
+    return this;
+  }
+
+  /**
+   * Routes an error thrown by a listener/middleware to the global error handler.
+   * Returns a Response to send back (only meaningful for the synchronous ack phase).
+   */
+  async #handleError(error: unknown, request: SlackMiddlewareRequest<E>): Promise<Response> {
+    const err = error instanceof Error ? error : new Error(String(error));
+    if (this.errorHandler) {
+      const response = await this.errorHandler({ error: err, request, body: request.body });
+      if (response instanceof Response) {
+        return response;
+      }
+    } else {
+      console.error(`Unhandled exception in a listener: ${err.stack ?? err.message}`);
+    }
+    return new Response("", { status: 500 });
+  }
+
+  /**
+   * Runs a lazy listener under ctx.waitUntil, routing any thrown error to the global error handler.
+   * Lazy listeners run detached from the HTTP response, so the handler's Response (if any) is ignored.
+   */
+  #startLazy(
+    ctx: ExecutionContext,
+    request: SlackMiddlewareRequest<E>,
+    // deno-lint-ignore no-explicit-any
+    lazy: (req: any) => Promise<void>,
+  ): void {
+    ctx.waitUntil(
+      (async () => {
+        try {
+          await lazy(request);
+        } catch (error) {
+          await this.#handleError(error, request);
+        }
+      })(),
+    );
   }
 
   /**
@@ -971,6 +1035,9 @@ export class SlackApp<E extends SlackEdgeAppEnv | SlackSocketModeAppEnv> {
         ...preAuthorizeRequest,
         context: authorizedContext,
       };
+      // Route any error thrown by a post-authorize middleware or a listener's ack phase
+      // to the global error handler. Lazy-listener errors are routed separately in #startLazy.
+      try {
       for (const middlware of this.postAuthorizeMiddleware) {
         const response = await middlware(baseRequest);
         if (response) {
@@ -1000,7 +1067,7 @@ export class SlackApp<E extends SlackEdgeAppEnv | SlackSocketModeAppEnv> {
           // Run all lazy handlers before ack (if configured)
           if (!this.startLazyListenerAfterAck) {
             for (const handler of matchedHandlers) {
-              ctx.waitUntil(handler.lazy(slackRequest));
+              this.#startLazy(ctx, slackRequest, handler.lazy);
             }
           }
 
@@ -1015,7 +1082,7 @@ export class SlackApp<E extends SlackEdgeAppEnv | SlackSocketModeAppEnv> {
           // Run all lazy handlers after ack (if configured)
           if (this.startLazyListenerAfterAck) {
             for (const handler of matchedHandlers) {
-              ctx.waitUntil(handler.lazy(slackRequest));
+              this.#startLazy(ctx, slackRequest, handler.lazy);
             }
           }
 
@@ -1027,7 +1094,7 @@ export class SlackApp<E extends SlackEdgeAppEnv | SlackSocketModeAppEnv> {
           const handler = new Assistant({ threadContextStore: this.assistantThreadContextStore }).threadContextChangedHandler;
           if (!this.startLazyListenerAfterAck) {
             const req = slackRequest as EventRequest<E, "assistant_thread_context_changed">;
-            ctx.waitUntil(handler(req));
+            this.#startLazy(ctx, req, handler);
             return toCompleteResponse();
           }
         }
@@ -1041,14 +1108,14 @@ export class SlackApp<E extends SlackEdgeAppEnv | SlackSocketModeAppEnv> {
           const handler = matcher(payload);
           if (handler) {
             if (!this.startLazyListenerAfterAck) {
-              ctx.waitUntil(handler.lazy(slackRequest));
+              this.#startLazy(ctx, slackRequest, handler.lazy);
             }
             const slackResponse = await handler.ack(slackRequest);
             if (isDebugLogEnabled(this.env.SLACK_LOGGING_LEVEL)) {
               console.log(`*** Slack response ***\n${prettyPrint(slackResponse)}`);
             }
             if (this.startLazyListenerAfterAck) {
-              ctx.waitUntil(handler.lazy(slackRequest));
+              this.#startLazy(ctx, slackRequest, handler.lazy);
             }
             return toCompleteResponse(slackResponse);
           }
@@ -1063,14 +1130,14 @@ export class SlackApp<E extends SlackEdgeAppEnv | SlackSocketModeAppEnv> {
           const handler = matcher(payload);
           if (handler) {
             if (!this.startLazyListenerAfterAck) {
-              ctx.waitUntil(handler.lazy(slackRequest));
+              this.#startLazy(ctx, slackRequest, handler.lazy);
             }
             const slackResponse = await handler.ack(slackRequest);
             if (isDebugLogEnabled(this.env.SLACK_LOGGING_LEVEL)) {
               console.log(`*** Slack response ***\n${prettyPrint(slackResponse)}`);
             }
             if (this.startLazyListenerAfterAck) {
-              ctx.waitUntil(handler.lazy(slackRequest));
+              this.#startLazy(ctx, slackRequest, handler.lazy);
             }
             return toCompleteResponse(slackResponse);
           }
@@ -1085,14 +1152,14 @@ export class SlackApp<E extends SlackEdgeAppEnv | SlackSocketModeAppEnv> {
           const handler = matcher(payload);
           if (handler) {
             if (!this.startLazyListenerAfterAck) {
-              ctx.waitUntil(handler.lazy(slackRequest));
+              this.#startLazy(ctx, slackRequest, handler.lazy);
             }
             const slackResponse = await handler.ack(slackRequest);
             if (isDebugLogEnabled(this.env.SLACK_LOGGING_LEVEL)) {
               console.log(`*** Slack response ***\n${prettyPrint(slackResponse)}`);
             }
             if (this.startLazyListenerAfterAck) {
-              ctx.waitUntil(handler.lazy(slackRequest));
+              this.#startLazy(ctx, slackRequest, handler.lazy);
             }
             return toCompleteResponse(slackResponse);
           }
@@ -1109,14 +1176,14 @@ export class SlackApp<E extends SlackEdgeAppEnv | SlackSocketModeAppEnv> {
           const handler = matcher(payload);
           if (handler) {
             if (!this.startLazyListenerAfterAck) {
-              ctx.waitUntil(handler.lazy(slackRequest));
+              this.#startLazy(ctx, slackRequest, handler.lazy);
             }
             const slackResponse = await handler.ack(slackRequest);
             if (isDebugLogEnabled(this.env.SLACK_LOGGING_LEVEL)) {
               console.log(`*** Slack response ***\n${prettyPrint(slackResponse)}`);
             }
             if (this.startLazyListenerAfterAck) {
-              ctx.waitUntil(handler.lazy(slackRequest));
+              this.#startLazy(ctx, slackRequest, handler.lazy);
             }
             return toCompleteResponse(slackResponse);
           }
@@ -1150,14 +1217,14 @@ export class SlackApp<E extends SlackEdgeAppEnv | SlackSocketModeAppEnv> {
           const handler = matcher(payload);
           if (handler) {
             if (!this.startLazyListenerAfterAck) {
-              ctx.waitUntil(handler.lazy(slackRequest));
+              this.#startLazy(ctx, slackRequest, handler.lazy);
             }
             const slackResponse = await handler.ack(slackRequest);
             if (isDebugLogEnabled(this.env.SLACK_LOGGING_LEVEL)) {
               console.log(`*** Slack response ***\n${prettyPrint(slackResponse)}`);
             }
             if (this.startLazyListenerAfterAck) {
-              ctx.waitUntil(handler.lazy(slackRequest));
+              this.#startLazy(ctx, slackRequest, handler.lazy);
             }
             return toCompleteResponse(slackResponse);
           }
@@ -1172,14 +1239,14 @@ export class SlackApp<E extends SlackEdgeAppEnv | SlackSocketModeAppEnv> {
           const handler = matcher(payload);
           if (handler) {
             if (!this.startLazyListenerAfterAck) {
-              ctx.waitUntil(handler.lazy(slackRequest));
+              this.#startLazy(ctx, slackRequest, handler.lazy);
             }
             const slackResponse = await handler.ack(slackRequest);
             if (isDebugLogEnabled(this.env.SLACK_LOGGING_LEVEL)) {
               console.log(`*** Slack response ***\n${prettyPrint(slackResponse)}`);
             }
             if (this.startLazyListenerAfterAck) {
-              ctx.waitUntil(handler.lazy(slackRequest));
+              this.#startLazy(ctx, slackRequest, handler.lazy);
             }
             return toCompleteResponse(slackResponse);
           }
@@ -1195,14 +1262,14 @@ export class SlackApp<E extends SlackEdgeAppEnv | SlackSocketModeAppEnv> {
           const handler = this.#appRateLimited(payload);
           if (handler) {
             if (!this.startLazyListenerAfterAck) {
-              ctx.waitUntil(handler.lazy(slackRequest));
+              this.#startLazy(ctx, slackRequest, handler.lazy);
             }
             const slackResponse = await handler.ack(slackRequest);
             if (isDebugLogEnabled(this.env.SLACK_LOGGING_LEVEL)) {
               console.log(`*** Slack response ***\n${prettyPrint(slackResponse)}`);
             }
             if (this.startLazyListenerAfterAck) {
-              ctx.waitUntil(handler.lazy(slackRequest));
+              this.#startLazy(ctx, slackRequest, handler.lazy);
             }
             return toCompleteResponse(slackResponse);
           }
@@ -1212,6 +1279,9 @@ export class SlackApp<E extends SlackEdgeAppEnv | SlackSocketModeAppEnv> {
       // TODO: Add code suggestion here
       console.log(`*** No listener found ***\n${JSON.stringify(baseRequest.body)}`);
       return new Response("No listener found", { status: 404 });
+      } catch (error) {
+        return await this.#handleError(error, baseRequest);
+      }
     }
     return new Response("Invalid signature", { status: 401 });
   }

--- a/src/app.ts
+++ b/src/app.ts
@@ -22,6 +22,7 @@ import {
   SlackAppContextWithChannelId,
   SlackAppContextWithRespond,
 } from "./context/context";
+import { startMessageStream } from "./context/message-stream";
 import { AuthorizeError, ConfigError } from "./errors";
 import { ExecutionContext, NoopExecutionContext } from "./execution-context";
 import {
@@ -1014,12 +1015,33 @@ export class SlackApp<E extends SlackEdgeAppEnv | SlackSocketModeAppEnv> {
                 : undefined,
               ...params,
             });
+          // sayStream
+          context.sayStream = async (params = {}) =>
+            await startMessageStream(client, {
+              channel: channel_id,
+              thread_ts: params.thread_ts ?? thread_ts,
+              recipient_user_id: params.recipient_user_id,
+              recipient_team_id: params.recipient_team_id,
+              markdown_text: params.markdown_text,
+              loading_messages: params.loading_messages,
+              metadata: threadContext ? { event_type: "assistant_thread_context", event_payload: { ...threadContext } } : undefined,
+            });
         } else {
           context.say = async (params) =>
             await client.chat.postMessage({
               channel: context.channelId,
               thread_ts: context.threadTs, // for assistant apps
               ...params,
+            });
+          // sayStream
+          context.sayStream = async (params = {}) =>
+            await startMessageStream(client, {
+              channel: context.channelId,
+              thread_ts: (params.thread_ts ?? context.threadTs) as string,
+              recipient_user_id: params.recipient_user_id,
+              recipient_team_id: params.recipient_team_id,
+              markdown_text: params.markdown_text,
+              loading_messages: params.loading_messages,
             });
         }
       }
@@ -1038,247 +1060,247 @@ export class SlackApp<E extends SlackEdgeAppEnv | SlackSocketModeAppEnv> {
       // Route any error thrown by a post-authorize middleware or a listener's ack phase
       // to the global error handler. Lazy-listener errors are routed separately in #startLazy.
       try {
-      for (const middlware of this.postAuthorizeMiddleware) {
-        const response = await middlware(baseRequest);
-        if (response) {
-          return toCompleteResponse(response);
-        }
-      }
-
-      const payload = body as SlackRequestBody;
-
-      if (body.type === PayloadType.EventsAPI) {
-        // Events API
-        const slackRequest: SlackRequest<E, SlackEvent<SupportedEventType>> = {
-          payload: body.event,
-          ...baseRequest,
-        };
-        // Collect all matching handlers to run them all
-        // This ensures both built-in handlers (e.g., token revocation) and user handlers are invoked
-        const matchedHandlers: SlackHandler<E, SlackEvent<SupportedEventType>>[] = [];
-        for (const matcher of this.#events) {
-          const handler = matcher(payload);
-          if (handler) {
-            matchedHandlers.push(handler);
+        for (const middlware of this.postAuthorizeMiddleware) {
+          const response = await middlware(baseRequest);
+          if (response) {
+            return toCompleteResponse(response);
           }
         }
 
-        if (matchedHandlers.length > 0) {
-          // Run all lazy handlers before ack (if configured)
-          if (!this.startLazyListenerAfterAck) {
+        const payload = body as SlackRequestBody;
+
+        if (body.type === PayloadType.EventsAPI) {
+          // Events API
+          const slackRequest: SlackRequest<E, SlackEvent<SupportedEventType>> = {
+            payload: body.event,
+            ...baseRequest,
+          };
+          // Collect all matching handlers to run them all
+          // This ensures both built-in handlers (e.g., token revocation) and user handlers are invoked
+          const matchedHandlers: SlackHandler<E, SlackEvent<SupportedEventType>>[] = [];
+          for (const matcher of this.#events) {
+            const handler = matcher(payload);
+            if (handler) {
+              matchedHandlers.push(handler);
+            }
+          }
+
+          if (matchedHandlers.length > 0) {
+            // Run all lazy handlers before ack (if configured)
+            if (!this.startLazyListenerAfterAck) {
+              for (const handler of matchedHandlers) {
+                this.#startLazy(ctx, slackRequest, handler.lazy);
+              }
+            }
+
+            // Run all ack handlers and log each response
             for (const handler of matchedHandlers) {
-              this.#startLazy(ctx, slackRequest, handler.lazy);
+              const slackResponse = await handler.ack(slackRequest);
+              if (isDebugLogEnabled(this.env.SLACK_LOGGING_LEVEL)) {
+                console.log(`*** Slack response ***\n${prettyPrint(slackResponse)}`);
+              }
             }
-          }
 
-          // Run all ack handlers and log each response
-          for (const handler of matchedHandlers) {
-            const slackResponse = await handler.ack(slackRequest);
-            if (isDebugLogEnabled(this.env.SLACK_LOGGING_LEVEL)) {
-              console.log(`*** Slack response ***\n${prettyPrint(slackResponse)}`);
+            // Run all lazy handlers after ack (if configured)
+            if (this.startLazyListenerAfterAck) {
+              for (const handler of matchedHandlers) {
+                this.#startLazy(ctx, slackRequest, handler.lazy);
+              }
             }
-          }
 
-          // Run all lazy handlers after ack (if configured)
-          if (this.startLazyListenerAfterAck) {
-            for (const handler of matchedHandlers) {
-              this.#startLazy(ctx, slackRequest, handler.lazy);
-            }
+            return toCompleteResponse("");
           }
-
-          return toCompleteResponse("");
-        }
-        if (payload.event?.type === "assistant_thread_context_changed") {
-          // When a developer does not register their customer listener for this event,
-          // SlackApp automatically calls the built-in one for ease of development.
-          const handler = new Assistant({ threadContextStore: this.assistantThreadContextStore }).threadContextChangedHandler;
-          if (!this.startLazyListenerAfterAck) {
-            const req = slackRequest as EventRequest<E, "assistant_thread_context_changed">;
-            this.#startLazy(ctx, req, handler);
-            return toCompleteResponse();
-          }
-        }
-      } else if (!body.type && body.command) {
-        // Slash commands
-        const slackRequest: SlackRequest<E, SlashCommand> = {
-          payload: body as SlashCommand,
-          ...baseRequest,
-        };
-        for (const matcher of this.#slashCommands) {
-          const handler = matcher(payload);
-          if (handler) {
+          if (payload.event?.type === "assistant_thread_context_changed") {
+            // When a developer does not register their customer listener for this event,
+            // SlackApp automatically calls the built-in one for ease of development.
+            const handler = new Assistant({ threadContextStore: this.assistantThreadContextStore }).threadContextChangedHandler;
             if (!this.startLazyListenerAfterAck) {
-              this.#startLazy(ctx, slackRequest, handler.lazy);
+              const req = slackRequest as EventRequest<E, "assistant_thread_context_changed">;
+              this.#startLazy(ctx, req, handler);
+              return toCompleteResponse();
             }
-            const slackResponse = await handler.ack(slackRequest);
-            if (isDebugLogEnabled(this.env.SLACK_LOGGING_LEVEL)) {
-              console.log(`*** Slack response ***\n${prettyPrint(slackResponse)}`);
-            }
-            if (this.startLazyListenerAfterAck) {
-              this.#startLazy(ctx, slackRequest, handler.lazy);
-            }
-            return toCompleteResponse(slackResponse);
           }
-        }
-      } else if (body.type === PayloadType.GlobalShortcut) {
-        // Global shortcuts
-        const slackRequest: SlackRequest<E, GlobalShortcut> = {
-          payload: body as GlobalShortcut,
-          ...baseRequest,
-        };
-        for (const matcher of this.#globalShorcuts) {
-          const handler = matcher(payload);
-          if (handler) {
-            if (!this.startLazyListenerAfterAck) {
-              this.#startLazy(ctx, slackRequest, handler.lazy);
+        } else if (!body.type && body.command) {
+          // Slash commands
+          const slackRequest: SlackRequest<E, SlashCommand> = {
+            payload: body as SlashCommand,
+            ...baseRequest,
+          };
+          for (const matcher of this.#slashCommands) {
+            const handler = matcher(payload);
+            if (handler) {
+              if (!this.startLazyListenerAfterAck) {
+                this.#startLazy(ctx, slackRequest, handler.lazy);
+              }
+              const slackResponse = await handler.ack(slackRequest);
+              if (isDebugLogEnabled(this.env.SLACK_LOGGING_LEVEL)) {
+                console.log(`*** Slack response ***\n${prettyPrint(slackResponse)}`);
+              }
+              if (this.startLazyListenerAfterAck) {
+                this.#startLazy(ctx, slackRequest, handler.lazy);
+              }
+              return toCompleteResponse(slackResponse);
             }
-            const slackResponse = await handler.ack(slackRequest);
-            if (isDebugLogEnabled(this.env.SLACK_LOGGING_LEVEL)) {
-              console.log(`*** Slack response ***\n${prettyPrint(slackResponse)}`);
-            }
-            if (this.startLazyListenerAfterAck) {
-              this.#startLazy(ctx, slackRequest, handler.lazy);
-            }
-            return toCompleteResponse(slackResponse);
           }
-        }
-      } else if (body.type === PayloadType.MessageShortcut) {
-        // Message shortcuts
-        const slackRequest: SlackRequest<E, MessageShortcut> = {
-          payload: body as MessageShortcut,
-          ...baseRequest,
-        };
-        for (const matcher of this.#messageShorcuts) {
-          const handler = matcher(payload);
-          if (handler) {
-            if (!this.startLazyListenerAfterAck) {
-              this.#startLazy(ctx, slackRequest, handler.lazy);
+        } else if (body.type === PayloadType.GlobalShortcut) {
+          // Global shortcuts
+          const slackRequest: SlackRequest<E, GlobalShortcut> = {
+            payload: body as GlobalShortcut,
+            ...baseRequest,
+          };
+          for (const matcher of this.#globalShorcuts) {
+            const handler = matcher(payload);
+            if (handler) {
+              if (!this.startLazyListenerAfterAck) {
+                this.#startLazy(ctx, slackRequest, handler.lazy);
+              }
+              const slackResponse = await handler.ack(slackRequest);
+              if (isDebugLogEnabled(this.env.SLACK_LOGGING_LEVEL)) {
+                console.log(`*** Slack response ***\n${prettyPrint(slackResponse)}`);
+              }
+              if (this.startLazyListenerAfterAck) {
+                this.#startLazy(ctx, slackRequest, handler.lazy);
+              }
+              return toCompleteResponse(slackResponse);
             }
-            const slackResponse = await handler.ack(slackRequest);
-            if (isDebugLogEnabled(this.env.SLACK_LOGGING_LEVEL)) {
-              console.log(`*** Slack response ***\n${prettyPrint(slackResponse)}`);
-            }
-            if (this.startLazyListenerAfterAck) {
-              this.#startLazy(ctx, slackRequest, handler.lazy);
-            }
-            return toCompleteResponse(slackResponse);
           }
-        }
-      } else if (body.type === PayloadType.BlockAction) {
-        // Block actions
-        // deno-lint-ignore no-explicit-any
-        const slackRequest: SlackRequest<E, BlockAction<any>> = {
+        } else if (body.type === PayloadType.MessageShortcut) {
+          // Message shortcuts
+          const slackRequest: SlackRequest<E, MessageShortcut> = {
+            payload: body as MessageShortcut,
+            ...baseRequest,
+          };
+          for (const matcher of this.#messageShorcuts) {
+            const handler = matcher(payload);
+            if (handler) {
+              if (!this.startLazyListenerAfterAck) {
+                this.#startLazy(ctx, slackRequest, handler.lazy);
+              }
+              const slackResponse = await handler.ack(slackRequest);
+              if (isDebugLogEnabled(this.env.SLACK_LOGGING_LEVEL)) {
+                console.log(`*** Slack response ***\n${prettyPrint(slackResponse)}`);
+              }
+              if (this.startLazyListenerAfterAck) {
+                this.#startLazy(ctx, slackRequest, handler.lazy);
+              }
+              return toCompleteResponse(slackResponse);
+            }
+          }
+        } else if (body.type === PayloadType.BlockAction) {
+          // Block actions
           // deno-lint-ignore no-explicit-any
-          payload: body as BlockAction<any>,
-          ...baseRequest,
-        };
-        for (const matcher of this.#blockActions) {
-          const handler = matcher(payload);
-          if (handler) {
-            if (!this.startLazyListenerAfterAck) {
-              this.#startLazy(ctx, slackRequest, handler.lazy);
+          const slackRequest: SlackRequest<E, BlockAction<any>> = {
+            // deno-lint-ignore no-explicit-any
+            payload: body as BlockAction<any>,
+            ...baseRequest,
+          };
+          for (const matcher of this.#blockActions) {
+            const handler = matcher(payload);
+            if (handler) {
+              if (!this.startLazyListenerAfterAck) {
+                this.#startLazy(ctx, slackRequest, handler.lazy);
+              }
+              const slackResponse = await handler.ack(slackRequest);
+              if (isDebugLogEnabled(this.env.SLACK_LOGGING_LEVEL)) {
+                console.log(`*** Slack response ***\n${prettyPrint(slackResponse)}`);
+              }
+              if (this.startLazyListenerAfterAck) {
+                this.#startLazy(ctx, slackRequest, handler.lazy);
+              }
+              return toCompleteResponse(slackResponse);
             }
-            const slackResponse = await handler.ack(slackRequest);
-            if (isDebugLogEnabled(this.env.SLACK_LOGGING_LEVEL)) {
-              console.log(`*** Slack response ***\n${prettyPrint(slackResponse)}`);
+          }
+        } else if (body.type === PayloadType.BlockSuggestion) {
+          // Block suggestions
+          const slackRequest: SlackRequest<E, BlockSuggestion> = {
+            payload: body as BlockSuggestion,
+            ...baseRequest,
+          };
+          for (const matcher of this.#blockSuggestions) {
+            const handler = matcher(payload);
+            if (handler) {
+              // Note that the only way to respond to a block_suggestion request
+              // is to send an HTTP response with options/option_groups.
+              // Thus, we don't support lazy handlers for this pattern.
+              const slackResponse = await handler.ack(slackRequest);
+              if (isDebugLogEnabled(this.env.SLACK_LOGGING_LEVEL)) {
+                console.log(`*** Slack response ***\n${prettyPrint(slackResponse)}`);
+              }
+              return toCompleteResponse(slackResponse);
             }
-            if (this.startLazyListenerAfterAck) {
-              this.#startLazy(ctx, slackRequest, handler.lazy);
+          }
+        } else if (body.type === PayloadType.ViewSubmission) {
+          // View submissions
+          const slackRequest: SlackRequest<E, ViewSubmission> = {
+            payload: body as ViewSubmission,
+            ...baseRequest,
+          };
+          for (const matcher of this.#viewSubmissions) {
+            const handler = matcher(payload);
+            if (handler) {
+              if (!this.startLazyListenerAfterAck) {
+                this.#startLazy(ctx, slackRequest, handler.lazy);
+              }
+              const slackResponse = await handler.ack(slackRequest);
+              if (isDebugLogEnabled(this.env.SLACK_LOGGING_LEVEL)) {
+                console.log(`*** Slack response ***\n${prettyPrint(slackResponse)}`);
+              }
+              if (this.startLazyListenerAfterAck) {
+                this.#startLazy(ctx, slackRequest, handler.lazy);
+              }
+              return toCompleteResponse(slackResponse);
             }
-            return toCompleteResponse(slackResponse);
+          }
+        } else if (body.type === PayloadType.ViewClosed) {
+          // View closed
+          const slackRequest: SlackRequest<E, ViewClosed> = {
+            payload: body as ViewClosed,
+            ...baseRequest,
+          };
+          for (const matcher of this.#viewClosed) {
+            const handler = matcher(payload);
+            if (handler) {
+              if (!this.startLazyListenerAfterAck) {
+                this.#startLazy(ctx, slackRequest, handler.lazy);
+              }
+              const slackResponse = await handler.ack(slackRequest);
+              if (isDebugLogEnabled(this.env.SLACK_LOGGING_LEVEL)) {
+                console.log(`*** Slack response ***\n${prettyPrint(slackResponse)}`);
+              }
+              if (this.startLazyListenerAfterAck) {
+                this.#startLazy(ctx, slackRequest, handler.lazy);
+              }
+              return toCompleteResponse(slackResponse);
+            }
+          }
+        } else if (body.type === PayloadType.AppRateLimited) {
+          // App rate limited
+          const slackRequest: SlackRequest<E, AppRateLimited> = {
+            payload: body as AppRateLimited,
+            ...baseRequest,
+          };
+          // Only a single appRateLimited handler is supported
+          if (this.#appRateLimited) {
+            const handler = this.#appRateLimited(payload);
+            if (handler) {
+              if (!this.startLazyListenerAfterAck) {
+                this.#startLazy(ctx, slackRequest, handler.lazy);
+              }
+              const slackResponse = await handler.ack(slackRequest);
+              if (isDebugLogEnabled(this.env.SLACK_LOGGING_LEVEL)) {
+                console.log(`*** Slack response ***\n${prettyPrint(slackResponse)}`);
+              }
+              if (this.startLazyListenerAfterAck) {
+                this.#startLazy(ctx, slackRequest, handler.lazy);
+              }
+              return toCompleteResponse(slackResponse);
+            }
           }
         }
-      } else if (body.type === PayloadType.BlockSuggestion) {
-        // Block suggestions
-        const slackRequest: SlackRequest<E, BlockSuggestion> = {
-          payload: body as BlockSuggestion,
-          ...baseRequest,
-        };
-        for (const matcher of this.#blockSuggestions) {
-          const handler = matcher(payload);
-          if (handler) {
-            // Note that the only way to respond to a block_suggestion request
-            // is to send an HTTP response with options/option_groups.
-            // Thus, we don't support lazy handlers for this pattern.
-            const slackResponse = await handler.ack(slackRequest);
-            if (isDebugLogEnabled(this.env.SLACK_LOGGING_LEVEL)) {
-              console.log(`*** Slack response ***\n${prettyPrint(slackResponse)}`);
-            }
-            return toCompleteResponse(slackResponse);
-          }
-        }
-      } else if (body.type === PayloadType.ViewSubmission) {
-        // View submissions
-        const slackRequest: SlackRequest<E, ViewSubmission> = {
-          payload: body as ViewSubmission,
-          ...baseRequest,
-        };
-        for (const matcher of this.#viewSubmissions) {
-          const handler = matcher(payload);
-          if (handler) {
-            if (!this.startLazyListenerAfterAck) {
-              this.#startLazy(ctx, slackRequest, handler.lazy);
-            }
-            const slackResponse = await handler.ack(slackRequest);
-            if (isDebugLogEnabled(this.env.SLACK_LOGGING_LEVEL)) {
-              console.log(`*** Slack response ***\n${prettyPrint(slackResponse)}`);
-            }
-            if (this.startLazyListenerAfterAck) {
-              this.#startLazy(ctx, slackRequest, handler.lazy);
-            }
-            return toCompleteResponse(slackResponse);
-          }
-        }
-      } else if (body.type === PayloadType.ViewClosed) {
-        // View closed
-        const slackRequest: SlackRequest<E, ViewClosed> = {
-          payload: body as ViewClosed,
-          ...baseRequest,
-        };
-        for (const matcher of this.#viewClosed) {
-          const handler = matcher(payload);
-          if (handler) {
-            if (!this.startLazyListenerAfterAck) {
-              this.#startLazy(ctx, slackRequest, handler.lazy);
-            }
-            const slackResponse = await handler.ack(slackRequest);
-            if (isDebugLogEnabled(this.env.SLACK_LOGGING_LEVEL)) {
-              console.log(`*** Slack response ***\n${prettyPrint(slackResponse)}`);
-            }
-            if (this.startLazyListenerAfterAck) {
-              this.#startLazy(ctx, slackRequest, handler.lazy);
-            }
-            return toCompleteResponse(slackResponse);
-          }
-        }
-      } else if (body.type === PayloadType.AppRateLimited) {
-        // App rate limited
-        const slackRequest: SlackRequest<E, AppRateLimited> = {
-          payload: body as AppRateLimited,
-          ...baseRequest,
-        };
-        // Only a single appRateLimited handler is supported
-        if (this.#appRateLimited) {
-          const handler = this.#appRateLimited(payload);
-          if (handler) {
-            if (!this.startLazyListenerAfterAck) {
-              this.#startLazy(ctx, slackRequest, handler.lazy);
-            }
-            const slackResponse = await handler.ack(slackRequest);
-            if (isDebugLogEnabled(this.env.SLACK_LOGGING_LEVEL)) {
-              console.log(`*** Slack response ***\n${prettyPrint(slackResponse)}`);
-            }
-            if (this.startLazyListenerAfterAck) {
-              this.#startLazy(ctx, slackRequest, handler.lazy);
-            }
-            return toCompleteResponse(slackResponse);
-          }
-        }
-      }
 
-      // TODO: Add code suggestion here
-      console.log(`*** No listener found ***\n${JSON.stringify(baseRequest.body)}`);
-      return new Response("No listener found", { status: 404 });
+        // TODO: Add code suggestion here
+        console.log(`*** No listener found ***\n${JSON.stringify(baseRequest.body)}`);
+        return new Response("No listener found", { status: 404 });
       } catch (error) {
         return await this.#handleError(error, baseRequest);
       }
@@ -1294,9 +1316,10 @@ export type MessageEventPattern = string | RegExp | undefined;
 /**
  * Events API request
  */
-export type EventRequest<E extends SlackAppEnv, T> = Extract<AnySlackEventWithChannelId, { type: T }> extends never
-  ? SlackRequest<E, Extract<AnySlackEvent, { type: T }>>
-  : SlackRequestWithChannelId<E, Extract<AnySlackEventWithChannelId, { type: T }>>;
+export type EventRequest<E extends SlackAppEnv, T> =
+  Extract<AnySlackEventWithChannelId, { type: T }> extends never
+    ? SlackRequest<E, Extract<AnySlackEvent, { type: T }>>
+    : SlackRequestWithChannelId<E, Extract<AnySlackEventWithChannelId, { type: T }>>;
 
 /**
  * Events API: "function_executed" event for custom functions in Workflow Builder

--- a/src/context/context.ts
+++ b/src/context/context.ts
@@ -11,6 +11,7 @@ import {
 import { PayloadType } from "../request/payload-types";
 import { AssistantThreadContextStore } from "../assistant/thread-context-store";
 import { AssistantThreadContext } from "../assistant/thread-context";
+import { MessageStream, SayStreamParams } from "./message-stream";
 
 /**
  * SlackApp context object that provides data available before performing authorize()
@@ -61,6 +62,11 @@ export type SlackAppContext = {
 export type SlackAppContextWithChannelId = {
   channelId: string;
   say: (params: Omit<ChatPostMessageRequest, "channel">) => Promise<ChatPostMessageResponse>;
+  /**
+   * say-style streaming helper. Auto-sources channel_id/thread_ts like `say`, starts an AI
+   * streaming message, and resolves to a handle with `.append()` and `.stop()`.
+   */
+  sayStream: (params?: SayStreamParams) => Promise<MessageStream>;
 } & SlackAppContext;
 
 export type SlackAppContextWithAssistantUtilities = SlackAppContextWithChannelId & {

--- a/src/context/message-stream.ts
+++ b/src/context/message-stream.ts
@@ -1,0 +1,106 @@
+import { SlackAPIClient, AnyMessageBlock, MessageMetadata, ChatAppendStreamResponse, ChatStopStreamResponse } from "slack-web-api-client";
+
+/**
+ * Input accepted by `MessageStream#append`. Either a markdown string or an object wrapping it.
+ */
+export type AppendInput = string | { markdown_text: string };
+
+/**
+ * Input accepted by `MessageStream#stop`. A markdown string, or an object that can also attach
+ * final Block Kit blocks / message metadata to the completed message.
+ */
+export type StopInput = string | { markdown_text?: string; blocks?: AnyMessageBlock[]; metadata?: MessageMetadata };
+
+/**
+ * A handle over an in-progress streaming message, returned by `startMessageStream` / `context.sayStream`.
+ * Append chunks as they are produced, then call `stop()` once to finalize the message.
+ */
+export interface MessageStream {
+  /** The `ts` of the streaming message, available once the stream has started. */
+  readonly ts: string;
+  /** The channel the message is being streamed into. */
+  readonly channel: string;
+  /** Appends a markdown chunk to the streaming message. */
+  append(input: AppendInput): Promise<ChatAppendStreamResponse>;
+  /** Finalizes the stream. Calling more than once is a no-op-safe error guard. */
+  stop(input?: StopInput): Promise<ChatStopStreamResponse>;
+}
+
+/**
+ * Parameters for starting a low-level message stream over chat.startStream/appendStream/stopStream.
+ */
+export interface MessageStreamStartParams {
+  channel: string;
+  /** Required by chat.startStream — the thread to stream the message into. */
+  thread_ts: string;
+  recipient_user_id?: string;
+  recipient_team_id?: string;
+  /** Initial markdown shown when the stream starts. Falls back to `loading_messages[0]`. */
+  markdown_text?: string;
+  /**
+   * Optional placeholder(s) shown while the first real chunk is produced.
+   * ponytail: chat.startStream/appendStream is append-only with no "replace", so only the
+   * first entry is used as the initial message — true timer-based cycling isn't supported on
+   * edge runtimes. Pass a single message unless you specifically want the first of several.
+   */
+  loading_messages?: string[];
+  /** Default metadata applied to the finalized message when `stop()` isn't given its own. */
+  metadata?: MessageMetadata;
+}
+
+/**
+ * Lower-level wrapper over chat.startStream → appendStream* → stopStream. Starts the stream
+ * immediately and resolves to a handle whose `append()` / `stop()` manage the rest of the lifecycle.
+ *
+ * @param client the SlackAPIClient to use
+ * @param params start parameters (channel/thread are required by the Slack API)
+ * @returns a MessageStream handle
+ */
+export async function startMessageStream(client: SlackAPIClient, params: MessageStreamStartParams): Promise<MessageStream> {
+  const { channel, thread_ts, recipient_user_id, recipient_team_id, loading_messages, metadata } = params;
+  const started = await client.chat.startStream({
+    channel,
+    thread_ts,
+    recipient_user_id,
+    recipient_team_id,
+    markdown_text: params.markdown_text ?? loading_messages?.[0],
+  });
+  const ts = started.ts;
+  if (!ts) {
+    throw new Error(`Failed to start a message stream: ${started.error ?? "unknown error"}`);
+  }
+
+  let stopped = false;
+  return {
+    ts,
+    channel,
+    async append(input) {
+      if (stopped) {
+        throw new Error("Cannot append to a message stream that has already been stopped");
+      }
+      const markdown_text = typeof input === "string" ? input : input.markdown_text;
+      return await client.chat.appendStream({ channel, ts, markdown_text });
+    },
+    async stop(input) {
+      stopped = true;
+      const args = typeof input === "string" ? { markdown_text: input } : { ...input };
+      if (args.metadata === undefined && metadata !== undefined) {
+        args.metadata = metadata;
+      }
+      return await client.chat.stopStream({ channel, ts, ...args });
+    },
+  };
+}
+
+/**
+ * Parameters for the `context.sayStream` helper. Channel and thread are auto-sourced from the
+ * listener context (like `say`), so all fields are optional overrides.
+ */
+export interface SayStreamParams {
+  markdown_text?: string;
+  /** Override the auto-sourced thread_ts (required by the Slack streaming API). */
+  thread_ts?: string;
+  recipient_user_id?: string;
+  recipient_team_id?: string;
+  loading_messages?: string[];
+}

--- a/src/error-handler.ts
+++ b/src/error-handler.ts
@@ -1,0 +1,30 @@
+import { SlackAppEnv } from "./app-env";
+import { SlackMiddlewareRequest } from "./request/request";
+
+/**
+ * The arguments passed to a global error handler registered via `app.error()`.
+ */
+export interface SlackAppErrorHandlerArgs<E extends SlackAppEnv> {
+  /** The error thrown by a post-authorize middleware or a listener (ack or lazy). */
+  error: Error;
+  /** The authorized request being processed, including its `context`, `headers`, and `env`. */
+  request: SlackMiddlewareRequest<E>;
+  /** Shortcut for `request.body` (the parsed request payload). */
+  // deno-lint-ignore no-explicit-any
+  body: Record<string, any>;
+}
+
+/**
+ * A single global error handler invoked when a post-authorize middleware or a listener throws.
+ *
+ * For errors thrown during the synchronous ack phase, returning a `Response` makes the app reply
+ * with it; returning nothing falls back to a 500 response. For errors thrown inside lazy listeners
+ * the app has already responded to Slack, so any returned `Response` is ignored (the handler is
+ * still useful for logging/reporting).
+ *
+ * This is independent of `authorizeErrorHandler`, which handles failures of the `authorize()` call
+ * that happen before any listener runs.
+ */
+export type SlackAppErrorHandler<E extends SlackAppEnv = SlackAppEnv> = (
+  args: SlackAppErrorHandlerArgs<E>,
+) => Promise<Response | void>;

--- a/src/index.ts
+++ b/src/index.ts
@@ -9,6 +9,7 @@ export * from "./assistant/thread-context";
 export * from "./assistant/thread-context-store";
 
 export * from "./errors";
+export * from "./error-handler";
 export * from "./oauth/error-codes";
 
 export * from "./handler/handler";

--- a/src/index.ts
+++ b/src/index.ts
@@ -26,6 +26,7 @@ export * from "./middleware/middleware";
 export * from "./middleware/built-in-middleware";
 
 export * from "./context/context";
+export * from "./context/message-stream";
 
 export * from "./oauth-app";
 export * from "./oauth/authorize-url-generator";

--- a/src/request/request-verification.ts
+++ b/src/request/request-verification.ts
@@ -7,18 +7,32 @@
  * @returns true if the given signature is valid
  */
 export async function verifySlackRequest(signingSecret: string, requestHeaders: Headers, requestBody: string): Promise<boolean> {
+  // A blank signing secret must never be used to verify a request. Without this guard,
+  // an HMAC computed with an empty key would still "verify", which an attacker who knows
+  // the secret is unset could forge. (mirrors bolt-js v4.7.2 hardening)
+  if (!signingSecret || signingSecret.trim() === "") {
+    console.log("signingSecret is empty!");
+    return false;
+  }
+
   const timestampHeader = requestHeaders.get("x-slack-request-timestamp");
   if (!timestampHeader) {
     console.log("x-slack-request-timestamp header is missing!");
     return false;
   }
-  const fiveMinutesAgoSeconds = Math.floor(Date.now() / 1000) - 60 * 5;
-  if (Number.parseInt(timestampHeader) < fiveMinutesAgoSeconds) {
+  const timestamp = Number.parseInt(timestampHeader);
+  if (Number.isNaN(timestamp)) {
+    // A non-numeric timestamp would otherwise slip past the skew check below (NaN comparisons are false).
+    console.log("x-slack-request-timestamp header is not a valid number!");
+    return false;
+  }
+  // Reject timestamps outside a +/-5 minute window to mitigate replay attacks.
+  if (Math.abs(Math.floor(Date.now() / 1000) - timestamp) > 60 * 5) {
     return false;
   }
 
   const signatureHeader = requestHeaders.get("x-slack-signature");
-  if (!timestampHeader || !signatureHeader) {
+  if (!signatureHeader) {
     console.log("x-slack-signature header is missing!");
     return false;
   }

--- a/test/error-handler.test.ts
+++ b/test/error-handler.test.ts
@@ -1,0 +1,143 @@
+import { assert, test, describe } from "vitest";
+import { SlackApp } from "../src/index";
+
+const signingSecret = "test-signing-secret";
+
+async function signRequest(secret: string, timestamp: number, body: string): Promise<string> {
+  const enc = new TextEncoder();
+  const key = await crypto.subtle.importKey("raw", enc.encode(secret), { name: "HMAC", hash: "SHA-256" }, false, ["sign"]);
+  const sig = await crypto.subtle.sign("HMAC", key, enc.encode(`v0:${timestamp}:${body}`));
+  const hex = Array.from(new Uint8Array(sig))
+    .map((b) => b.toString(16).padStart(2, "0"))
+    .join("");
+  return `v0=${hex}`;
+}
+
+async function createSignedRequest(secret: string, body: object): Promise<Request> {
+  const bodyStr = JSON.stringify(body);
+  const ts = Math.floor(Date.now() / 1000);
+  const signature = await signRequest(secret, ts, bodyStr);
+  return new Request("https://example.com/slack/events", {
+    method: "POST",
+    headers: {
+      "Content-Type": "application/json",
+      "x-slack-request-timestamp": ts.toString(),
+      "x-slack-signature": signature,
+    },
+    body: bodyStr,
+  });
+}
+
+const mockAuthorize = async () => ({
+  enterpriseId: undefined,
+  teamId: "T111",
+  team: "T111",
+  botId: "B111",
+  botUserId: "U111",
+  botToken: "xoxb-test",
+  botScopes: [],
+});
+
+const appMentionBody = {
+  type: "event_callback",
+  team_id: "T111",
+  api_app_id: "A111",
+  event: { type: "app_mention", user: "U123", text: "<@U111> hi", ts: "1.1", channel: "C111", event_ts: "1.1" },
+  event_id: "Ev111",
+  event_time: 1,
+};
+
+// Lazy listeners run detached via ctx.waitUntil; let their microtasks settle.
+const flush = () => new Promise((r) => setTimeout(r, 0));
+
+describe("Global error handler (app.error)", () => {
+  test("invokes the registered handler when a lazy listener throws", async () => {
+    const app = new SlackApp({ env: { SLACK_SIGNING_SECRET: signingSecret, SLACK_BOT_TOKEN: "xoxb-test" }, authorize: mockAuthorize });
+
+    let captured: { message: string; body: unknown } | undefined;
+    app.error(async ({ error, body }) => {
+      captured = { message: error.message, body };
+    });
+    app.event("app_mention", async () => {
+      throw new Error("boom");
+    });
+
+    const res = await app.run(await createSignedRequest(signingSecret, appMentionBody));
+    await flush();
+
+    assert.equal(res.status, 200); // ack still succeeds; lazy failure is out-of-band
+    assert.exists(captured);
+    assert.equal(captured!.message, "boom");
+    assert.equal((captured!.body as { event: { type: string } }).event.type, "app_mention");
+  });
+
+  test("can be registered via the constructor option", async () => {
+    let called = false;
+    const app = new SlackApp({
+      env: { SLACK_SIGNING_SECRET: signingSecret, SLACK_BOT_TOKEN: "xoxb-test" },
+      authorize: mockAuthorize,
+      errorHandler: async () => {
+        called = true;
+      },
+    });
+    app.event("app_mention", async () => {
+      throw new Error("boom");
+    });
+
+    await app.run(await createSignedRequest(signingSecret, appMentionBody));
+    await flush();
+    assert.isTrue(called);
+  });
+
+  test("default path (no handler) does not throw and still acks", async () => {
+    const app = new SlackApp({ env: { SLACK_SIGNING_SECRET: signingSecret, SLACK_BOT_TOKEN: "xoxb-test" }, authorize: mockAuthorize });
+    app.event("app_mention", async () => {
+      throw new Error("boom");
+    });
+
+    const res = await app.run(await createSignedRequest(signingSecret, appMentionBody));
+    await flush();
+    assert.equal(res.status, 200);
+  });
+
+  test("routes errors thrown by post-authorize middleware and can return a custom Response", async () => {
+    const app = new SlackApp({ env: { SLACK_SIGNING_SECRET: signingSecret, SLACK_BOT_TOKEN: "xoxb-test" }, authorize: mockAuthorize });
+    app.use(async () => {
+      throw new Error("middleware failed");
+    });
+    let seen: string | undefined;
+    app.error(async ({ error }) => {
+      seen = error.message;
+      return new Response("handled", { status: 503 });
+    });
+
+    const res = await app.run(await createSignedRequest(signingSecret, appMentionBody));
+    assert.equal(seen, "middleware failed");
+    assert.equal(res.status, 503);
+    assert.equal(await res.text(), "handled");
+  });
+
+  test("does not interfere with the authorizeErrorHandler", async () => {
+    // An authorize failure must go to authorizeErrorHandler, not the listener errorHandler.
+    let listenerErrorCalled = false;
+    const app = new SlackApp({
+      env: { SLACK_SIGNING_SECRET: signingSecret, SLACK_BOT_TOKEN: "xoxb-test" },
+      authorize: async () => {
+        const err = new Error("nope");
+        err.name = "AuthorizeError";
+        throw err;
+      },
+      authorizeErrorHandler: async () => new Response("auth handled", { status: 401 }),
+    });
+    app.error(async () => {
+      listenerErrorCalled = true;
+    });
+    app.event("app_mention", async () => {});
+
+    const res = await app.run(await createSignedRequest(signingSecret, appMentionBody));
+    await flush();
+    assert.equal(res.status, 401);
+    assert.equal(await res.text(), "auth handled");
+    assert.isFalse(listenerErrorCalled);
+  });
+});

--- a/test/message-stream.test.ts
+++ b/test/message-stream.test.ts
@@ -1,0 +1,174 @@
+import { assert, expect, test, describe, vi, afterEach } from "vitest";
+import { SlackApp, SlackAPIClient, startMessageStream, ExecutionContext } from "../src/index";
+
+const signingSecret = "test-signing-secret";
+
+// --- helpers ---------------------------------------------------------------
+
+async function signRequest(secret: string, timestamp: number, body: string): Promise<string> {
+  const enc = new TextEncoder();
+  const key = await crypto.subtle.importKey("raw", enc.encode(secret), { name: "HMAC", hash: "SHA-256" }, false, ["sign"]);
+  const sig = await crypto.subtle.sign("HMAC", key, enc.encode(`v0:${timestamp}:${body}`));
+  const hex = Array.from(new Uint8Array(sig))
+    .map((b) => b.toString(16).padStart(2, "0"))
+    .join("");
+  return `v0=${hex}`;
+}
+
+async function createSignedRequest(secret: string, body: object): Promise<Request> {
+  const bodyStr = JSON.stringify(body);
+  const ts = Math.floor(Date.now() / 1000);
+  const signature = await signRequest(secret, ts, bodyStr);
+  return new Request("https://example.com/slack/events", {
+    method: "POST",
+    headers: { "Content-Type": "application/json", "x-slack-request-timestamp": ts.toString(), "x-slack-signature": signature },
+    body: bodyStr,
+  });
+}
+
+// Records every chat.*Stream call against a fake client.
+function fakeClient() {
+  const calls: { method: string; args: Record<string, unknown> }[] = [];
+  const record = (method: string, ret: Record<string, unknown>) => async (args: Record<string, unknown>) => {
+    calls.push({ method, args });
+    return { ok: true, ...ret };
+  };
+  const client = {
+    chat: {
+      startStream: record("startStream", { ts: "1700000000.000100", channel: "C111" }),
+      appendStream: record("appendStream", {}),
+      stopStream: record("stopStream", {}),
+    },
+  } as unknown as SlackAPIClient;
+  return { client, calls };
+}
+
+// Collects lazy listener promises so tests can await their completion.
+class CollectingExecutionContext implements ExecutionContext {
+  promises: Promise<unknown>[] = [];
+  // deno-lint-ignore no-explicit-any
+  waitUntil(promise: Promise<any>): void {
+    this.promises.push(promise);
+  }
+}
+
+// --- low-level factory -----------------------------------------------------
+
+describe("startMessageStream", () => {
+  test("drives start -> append -> stop in order", async () => {
+    const { client, calls } = fakeClient();
+    const stream = await startMessageStream(client, { channel: "C111", thread_ts: "1.1", markdown_text: "hello" });
+
+    assert.equal(stream.ts, "1700000000.000100");
+    await stream.append("more");
+    await stream.append({ markdown_text: " and more" });
+    await stream.stop("done");
+
+    assert.deepEqual(
+      calls.map((c) => c.method),
+      ["startStream", "appendStream", "appendStream", "stopStream"],
+    );
+    assert.deepEqual(calls[0].args, {
+      channel: "C111",
+      thread_ts: "1.1",
+      recipient_user_id: undefined,
+      recipient_team_id: undefined,
+      markdown_text: "hello",
+    });
+    assert.deepEqual(calls[1].args, { channel: "C111", ts: "1700000000.000100", markdown_text: "more" });
+    assert.deepEqual(calls[2].args, { channel: "C111", ts: "1700000000.000100", markdown_text: " and more" });
+    assert.deepEqual(calls[3].args, { channel: "C111", ts: "1700000000.000100", markdown_text: "done" });
+  });
+
+  test("uses loading_messages[0] as the initial markdown when none is given", async () => {
+    const { client, calls } = fakeClient();
+    await startMessageStream(client, { channel: "C111", thread_ts: "1.1", loading_messages: ["Thinking…", "Still thinking…"] });
+    assert.equal(calls[0].args.markdown_text, "Thinking…");
+  });
+
+  test("applies default metadata on stop unless overridden", async () => {
+    const { client, calls } = fakeClient();
+    const meta = { event_type: "assistant_thread_context", event_payload: { channel_id: "C111" } };
+    const stream = await startMessageStream(client, { channel: "C111", thread_ts: "1.1", metadata: meta });
+    await stream.stop();
+    assert.deepEqual(calls[1].args.metadata, meta);
+  });
+
+  test("throws when the stream fails to start", async () => {
+    const client = {
+      chat: { startStream: async () => ({ ok: false, error: "channel_not_found" }) },
+    } as unknown as SlackAPIClient;
+    await expect(startMessageStream(client, { channel: "C111", thread_ts: "1.1" })).rejects.toThrow(/channel_not_found/);
+  });
+
+  test("refuses to append after stop", async () => {
+    const { client } = fakeClient();
+    const stream = await startMessageStream(client, { channel: "C111", thread_ts: "1.1" });
+    await stream.stop();
+    await expect(stream.append("nope")).rejects.toThrow(/already been stopped/);
+  });
+});
+
+// --- context.sayStream wiring (end-to-end via app.run) ---------------------
+
+describe("context.sayStream", () => {
+  afterEach(() => vi.unstubAllGlobals());
+
+  test("auto-sources channel_id and threads ts from start through append/stop", async () => {
+    const apiCalls: { method: string; body: URLSearchParams }[] = [];
+    vi.stubGlobal("fetch", async (input: Request | string) => {
+      const url = typeof input === "string" ? input : input.url;
+      const method = url.split("/api/")[1];
+      const body = typeof input === "string" ? new URLSearchParams() : new URLSearchParams(await input.text());
+      apiCalls.push({ method, body });
+      const ret = method === "chat.startStream" ? { ok: true, ts: "1700000000.000999" } : { ok: true };
+      return new Response(JSON.stringify(ret), { headers: { "content-type": "application/json" } });
+    });
+
+    const app = new SlackApp({
+      env: { SLACK_SIGNING_SECRET: signingSecret, SLACK_BOT_TOKEN: "xoxb-test" },
+      authorize: async () => ({
+        enterpriseId: undefined,
+        teamId: "T111",
+        team: "T111",
+        botId: "B111",
+        botUserId: "U111",
+        botToken: "xoxb-test",
+        botScopes: [],
+      }),
+    });
+
+    app.event("app_mention", async ({ context }) => {
+      const stream = await context.sayStream({ thread_ts: "100.200", markdown_text: "Working on it" });
+      await stream.append("partial");
+      await stream.stop("final");
+    });
+
+    const body = {
+      type: "event_callback",
+      team_id: "T111",
+      api_app_id: "A111",
+      event: { type: "app_mention", user: "U123", text: "<@U111> hi", ts: "1.1", channel: "C999", event_ts: "1.1" },
+      event_id: "Ev1",
+      event_time: 1,
+    };
+    const ctx = new CollectingExecutionContext();
+    await app.run(await createSignedRequest(signingSecret, body), ctx);
+    await Promise.all(ctx.promises);
+
+    const streamCalls = apiCalls.filter((c) => c.method.endsWith("Stream"));
+    assert.deepEqual(
+      streamCalls.map((c) => c.method),
+      ["chat.startStream", "chat.appendStream", "chat.stopStream"],
+    );
+    // channel auto-sourced from the event payload
+    assert.equal(streamCalls[0].body.get("channel"), "C999");
+    assert.equal(streamCalls[0].body.get("thread_ts"), "100.200");
+    assert.equal(streamCalls[0].body.get("markdown_text"), "Working on it");
+    // ts returned by start flows into append + stop
+    assert.equal(streamCalls[1].body.get("ts"), "1700000000.000999");
+    assert.equal(streamCalls[1].body.get("channel"), "C999");
+    assert.equal(streamCalls[2].body.get("ts"), "1700000000.000999");
+    assert.equal(streamCalls[2].body.get("markdown_text"), "final");
+  });
+});

--- a/test/request-verification.test.ts
+++ b/test/request-verification.test.ts
@@ -1,0 +1,100 @@
+import { assert, test, describe } from "vitest";
+import { SlackApp, verifySlackRequest } from "../src/index";
+
+const signingSecret = "test-signing-secret";
+
+async function sign(secret: string, timestamp: number, body: string): Promise<string> {
+  const enc = new TextEncoder();
+  const key = await crypto.subtle.importKey("raw", enc.encode(secret), { name: "HMAC", hash: "SHA-256" }, false, ["sign"]);
+  const sig = await crypto.subtle.sign("HMAC", key, enc.encode(`v0:${timestamp}:${body}`));
+  const hex = Array.from(new Uint8Array(sig))
+    .map((b) => b.toString(16).padStart(2, "0"))
+    .join("");
+  return `v0=${hex}`;
+}
+
+function headers(timestamp: number, signature: string): Headers {
+  return new Headers({
+    "x-slack-request-timestamp": timestamp.toString(),
+    "x-slack-signature": signature,
+  });
+}
+
+describe("Request signature verification", () => {
+  test("rejects an empty signing secret at construction", () => {
+    assert.throws(
+      () => new SlackApp({ env: { SLACK_SIGNING_SECRET: "", SLACK_BOT_TOKEN: "xoxb-" } }),
+      /SLACK_SIGNING_SECRET is required/,
+    );
+  });
+
+  test("rejects a whitespace-only signing secret at construction", () => {
+    assert.throws(
+      () => new SlackApp({ env: { SLACK_SIGNING_SECRET: "   ", SLACK_BOT_TOKEN: "xoxb-" } }),
+      /SLACK_SIGNING_SECRET is required/,
+    );
+  });
+
+  test("verifySlackRequest returns false for a blank secret without attempting an HMAC", async () => {
+    const body = "payload=1";
+    const ts = Math.floor(Date.now() / 1000);
+    // The guard must short-circuit before importing a (zero-length) key, regardless of signature.
+    assert.equal(await verifySlackRequest("", headers(ts, "v0=deadbeef"), body), false);
+    assert.equal(await verifySlackRequest("   ", headers(ts, "v0=deadbeef"), body), false);
+  });
+
+  test("accepts a valid request", async () => {
+    const body = "token=abc&ssl_check=0";
+    const ts = Math.floor(Date.now() / 1000);
+    const sig = await sign(signingSecret, ts, body);
+    assert.equal(await verifySlackRequest(signingSecret, headers(ts, sig), body), true);
+  });
+
+  test("rejects a tampered signature", async () => {
+    const body = "token=abc";
+    const ts = Math.floor(Date.now() / 1000);
+    const sig = await sign(signingSecret, ts, body);
+    // Flip the request body after signing.
+    assert.equal(await verifySlackRequest(signingSecret, headers(ts, sig), `${body}&evil=1`), false);
+  });
+
+  test("rejects an expired timestamp", async () => {
+    const body = "token=abc";
+    const ts = Math.floor(Date.now() / 1000) - 60 * 10; // 10 minutes old
+    const sig = await sign(signingSecret, ts, body);
+    assert.equal(await verifySlackRequest(signingSecret, headers(ts, sig), body), false);
+  });
+
+  test("rejects a non-numeric timestamp", async () => {
+    const body = "token=abc";
+    const sig = await sign(signingSecret, NaN as unknown as number, body);
+    const h = new Headers({ "x-slack-request-timestamp": "not-a-number", "x-slack-signature": sig });
+    assert.equal(await verifySlackRequest(signingSecret, h, body), false);
+  });
+
+  test("a forged ssl_check that is not exactly '1' is still signature-verified", async () => {
+    // slack-edge only skips verification for an exact ssl_check=1 with a token.
+    // Any other value falls through to normal verification and must fail without a valid signature.
+    const app = new SlackApp({ env: { SLACK_SIGNING_SECRET: signingSecret, SLACK_BOT_TOKEN: "xoxb-" } });
+    const body = "ssl_check=foo&token=abc";
+    const request = new Request("https://example.com/slack/events", {
+      method: "POST",
+      headers: { "Content-Type": "application/x-www-form-urlencoded", "x-slack-request-timestamp": "1", "x-slack-signature": "v0=deadbeef" },
+      body,
+    });
+    const res = await app.run(request);
+    assert.equal(res.status, 401);
+  });
+
+  test("an exact ssl_check=1 with a token is acknowledged without a signature", async () => {
+    const app = new SlackApp({ env: { SLACK_SIGNING_SECRET: signingSecret, SLACK_BOT_TOKEN: "xoxb-" } });
+    const body = "ssl_check=1&token=abc";
+    const request = new Request("https://example.com/slack/events", {
+      method: "POST",
+      headers: { "Content-Type": "application/x-www-form-urlencoded" },
+      body,
+    });
+    const res = await app.run(request);
+    assert.equal(res.status, 200);
+  });
+});


### PR DESCRIPTION
Three independent, backward-compatible additions that close gaps relative to Bolt-JS, each as its own commit. **Task 3 is a security fix and is a standalone commit** (`b90b2a0`) — it can be cherry-picked/reviewed on its own.

## 1. Harden request signature verification (security) — `b90b2a0`
Audit of `src/request/request-verification.ts` + `src/app.ts`:
- **Empty/blank signing secret (was partially vulnerable).** The constructor rejected `""`/`undefined` but not whitespace-only (`"   "`), and `verifySlackRequest` had no guard — it would import a key and compute an HMAC with a blank secret. Now the constructor rejects `.trim() === ""` and `verifySlackRequest` returns `false` for a blank secret before touching crypto.
- **Timestamp skew (had a gap).** A non-numeric timestamp produced `NaN`, and `NaN < x` is always `false`, so it slipped past the old one-sided check. Now rejects `NaN` and uses a symmetric ±5-minute window.
- **`ssl_check` bypass — not vulnerable.** Already requires an exact `ssl_check === "1"` (with a token); pinned with tests, left as-is.
- **Constant-time compare — fine.** Uses `crypto.subtle.verify` (platform constant-time), not a manual hex compare.

## 2. Global error handler `app.error()` — `a65468a`
Bolt-style catch-all for errors thrown by post-authorize middleware or listeners. Registered via `app.error(handler)` or the `errorHandler` constructor option; receives `{ error, request, body }`.
- Ack-phase + middleware errors are caught and routed (handler may return a `Response`, otherwise a 500 is sent).
- Lazy-listener errors (detached under `waitUntil`) are routed too, via a `#startLazy` wrapper around every lazy invocation.
- No handler registered → log + safe response, preserving prior behavior.
- Independent of `authorizeErrorHandler` (handled earlier in a separate path) — a test asserts the two don't conflict.

## 3. AI streaming helpers `sayStream` / `startMessageStream` — `ba0cd6d`
Mirrors Bolt-JS's `sayStream`/`chatStream` over `chat.startStream/appendStream/stopStream`, adapted for edge runtimes.
- `context.sayStream(params?)` — `say`-style helper that auto-sources `channel_id`/`thread_ts` (and, in an assistant thread, attaches thread-context metadata) and resolves to a handle with `.append()` / `.stop()`. Works in both Assistant utilities and plain `app.event`/`app.message` listeners.
- `startMessageStream(client, params)` — lower-level lifecycle wrapper (start → append* → stop) with optional `loading_messages` and default finalize metadata; guards against append-after-stop and surfaces start errors.
- `loading_messages` cycling is intentionally not timer-driven — the underlying API is append-only with no replace, so the first entry seeds the initial message.

## Notes for reviewers
- Public API additions only; nothing existing changed shape. `say` is untouched.
- README updated for `app.error()` and the streaming helpers.
- `npm run build`, `knip` (lint), and `vitest` all pass — **44 tests**, including new coverage for all three tasks (mock-client call-sequence assertions + an end-to-end `app.run` fetch-mock test for `sayStream`).
